### PR TITLE
Add proof support and update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@
 all: test install
 
 NOVENDOR = go list github.com/tendermint/basecoin/... | grep -v /vendor/
-    
-install: 
+
+build:
+	go build github.com/tendermint/basecoin/cmd/...
+
+install:
 	go install github.com/tendermint/basecoin/cmd/...
 
 test:
@@ -20,4 +23,4 @@ update_deps:
 get_vendor_deps:
 	go get github.com/Masterminds/glide
 	glide install
-	
+

--- a/app/app.go
+++ b/app/app.go
@@ -126,6 +126,15 @@ func (app *Basecoin) Query(query []byte) (res abci.Result) {
 	return app.eyesCli.QuerySync(query)
 }
 
+// TMSP::Query
+func (app *Basecoin) Proof(key []byte, height uint64) (res abci.Result) {
+	if len(key) == 0 {
+		return abci.ErrEncodingError.SetLog("Key cannot be zero length")
+	}
+
+	return app.eyesCli.ProofSync(key, height)
+}
+
 // TMSP::Commit
 func (app *Basecoin) Commit() (res abci.Result) {
 

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/pkg/errors"
+	cmn "github.com/tendermint/go-common"
+)
+
+func (app *Basecoin) LoadGenesis(path string) error {
+	kvz, err := loadGenesis(path)
+	if err != nil {
+		return err
+	}
+	for _, kv := range kvz {
+		log := app.SetOption(kv.Key, kv.Value)
+		// TODO: remove debug output
+		fmt.Printf("Set %v=%v. Log: %v", kv.Key, kv.Value, log)
+	}
+	return nil
+}
+
+type keyValue struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func loadGenesis(filePath string) (kvz []keyValue, err error) {
+	kvz_ := []interface{}{}
+	bytes, err := cmn.ReadFile(filePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading genesis file")
+	}
+	err = json.Unmarshal(bytes, &kvz_)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing genesis file")
+	}
+	if len(kvz_)%2 != 0 {
+		return nil, errors.New("genesis cannot have an odd number of items.  Format = [key1, value1, key2, value2, ...]")
+	}
+	for i := 0; i < len(kvz_); i += 2 {
+		keyIfc := kvz_[i]
+		valueIfc := kvz_[i+1]
+		var key, value string
+		key, ok := keyIfc.(string)
+		if !ok {
+			return nil, errors.Errorf("genesis had invalid key %v of type %v", keyIfc, reflect.TypeOf(keyIfc))
+		}
+		if value_, ok := valueIfc.(string); ok {
+			value = value_
+		} else {
+			valueBytes, err := json.Marshal(valueIfc)
+			if err != nil {
+				return nil, errors.Errorf("genesis had invalid value %v: %v", value_, err.Error())
+			}
+			value = string(valueBytes)
+		}
+		kvz = append(kvz, keyValue{key, value})
+	}
+	return kvz, nil
+}

--- a/cmd/paytovote/main.go
+++ b/cmd/paytovote/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tendermint/abci/server"
 	"github.com/tendermint/basecoin/app"
+	"github.com/tendermint/basecoin/plugins/counter"
 	cmn "github.com/tendermint/go-common"
 	eyes "github.com/tendermint/merkleeyes/client"
 )
@@ -23,6 +24,11 @@ func main() {
 
 	// Create Basecoin app
 	app := app.NewBasecoin(eyesCli)
+
+	// add plugins
+	// TODO: add some more, like the cool voting app
+	counter := counter.New("counter")
+	app.RegisterPlugin(counter)
 
 	// If genesis file was specified, set key-value options
 	if *genFilePath != "" {

--- a/glide.lock
+++ b/glide.lock
@@ -41,7 +41,7 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: github.com/tendermint/abci
-  version: 05096de3687ac582bec63860b3dd384acd9149aa
+  version: fdc047ae7af0f0189dd9f21b932eb92ce455ffa5
   subpackages:
   - client
   - server
@@ -85,12 +85,12 @@ imports:
   subpackages:
   - term
 - name: github.com/tendermint/merkleeyes
-  version: 2cf87e5f049ab6131aa4ea188c1b5b629d9b3bf9
+  version: 4340a256d3d0fb44831826cf68aa1f6f4a2a151c
   subpackages:
   - app
   - client
 - name: github.com/tendermint/tendermint
-  version: cf0cb9558aaecbf3ddb071eb863df77e55d828ed
+  version: 00d4157b80b4052b21d27460b33e411bfe07d79d
   subpackages:
   - rpc/core/types
   - types

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,9 +15,8 @@ import:
 - package: github.com/tendermint/merkleeyes
   version: develop
 - package: github.com/tendermint/tendermint
-  version: develop
+  version: abci_proof
 - package: github.com/tendermint/abci
-  version: develop
-
+  version: abci_proof
 - package: github.com/gorilla/websocket
   version: v1.1.0

--- a/plugins/counter/counter.go
+++ b/plugins/counter/counter.go
@@ -32,7 +32,7 @@ func (cp *CounterPlugin) StateKey() []byte {
 	return []byte(fmt.Sprintf("CounterPlugin{name=%v}.State", cp.name))
 }
 
-func NewCounterPlugin(name string) *CounterPlugin {
+func New(name string) *CounterPlugin {
 	return &CounterPlugin{
 		name: name,
 	}
@@ -43,7 +43,6 @@ func (cp *CounterPlugin) SetOption(store types.KVStore, key string, value string
 }
 
 func (cp *CounterPlugin) RunTx(store types.KVStore, ctx types.CallContext, txBytes []byte) (res abci.Result) {
-
 	// Decode tx
 	var tx CounterTx
 	err := wire.ReadBinaryBytes(txBytes, &tx)

--- a/plugins/counter/counter_test.go
+++ b/plugins/counter/counter_test.go
@@ -23,7 +23,7 @@ func TestCounterPlugin(t *testing.T) {
 
 	// Add Counter plugin
 	counterPluginName := "testcounter"
-	counterPlugin := NewCounterPlugin(counterPluginName)
+	counterPlugin := New(counterPluginName)
 	bcApp.RegisterPlugin(counterPlugin)
 
 	// Account initialization


### PR DESCRIPTION
This is a minor update to basecoin to expose the proof call through tendermint / abci.  Mainly updating all the dependencies.

@mappum Please checkout and run this branch (along with the same named branch of the tendermint core) when building your light-client that wants to check basecoin proofs.