### PR TITLE
Implement abci.BlockchainAware interface

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"fmt"
 	"strings"
 
 	abci "github.com/tendermint/abci/types"
@@ -42,7 +41,7 @@ func (app *Basecoin) GetState() *sm.State {
 	return app.state.CacheWrap()
 }
 
-// TMSP::Info
+// ABCI::Info
 func (app *Basecoin) Info() abci.ResponseInfo {
 	return abci.ResponseInfo{Data: Fmt("Basecoin v%v", version)}
 }
@@ -51,7 +50,7 @@ func (app *Basecoin) RegisterPlugin(plugin types.Plugin) {
 	app.plugins.RegisterPlugin(plugin)
 }
 
-// TMSP::SetOption
+// ABCI::SetOption
 func (app *Basecoin) SetOption(key string, value string) (log string) {
 	PluginName, key := splitKey(key)
 	if PluginName != PluginNameBase {
@@ -81,7 +80,7 @@ func (app *Basecoin) SetOption(key string, value string) (log string) {
 	}
 }
 
-// TMSP::DeliverTx
+// ABCI::DeliverTx
 func (app *Basecoin) DeliverTx(txBytes []byte) (res abci.Result) {
 	if len(txBytes) > maxTxSize {
 		return abci.ErrBaseEncodingError.AppendLog("Tx size exceeds maximum")
@@ -102,13 +101,11 @@ func (app *Basecoin) DeliverTx(txBytes []byte) (res abci.Result) {
 	return res
 }
 
-// TMSP::CheckTx
+// ABCI::CheckTx
 func (app *Basecoin) CheckTx(txBytes []byte) (res abci.Result) {
 	if len(txBytes) > maxTxSize {
 		return abci.ErrBaseEncodingError.AppendLog("Tx size exceeds maximum")
 	}
-
-	fmt.Printf("%X\n", txBytes)
 
 	// Decode tx
 	var tx types.Tx
@@ -125,7 +122,7 @@ func (app *Basecoin) CheckTx(txBytes []byte) (res abci.Result) {
 	return abci.OK
 }
 
-// TMSP::Query
+// ABCI::Query
 func (app *Basecoin) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQuery) {
 	if len(reqQuery.Data) == 0 {
 		resQuery.Log = "Query cannot be zero length"
@@ -142,7 +139,7 @@ func (app *Basecoin) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQu
 	return
 }
 
-// TMSP::Commit
+// ABCI::Commit
 func (app *Basecoin) Commit() (res abci.Result) {
 
 	// Commit state
@@ -157,25 +154,25 @@ func (app *Basecoin) Commit() (res abci.Result) {
 	return res
 }
 
-// TMSP::InitChain
+// ABCI::InitChain
 func (app *Basecoin) InitChain(validators []*abci.Validator) {
 	for _, plugin := range app.plugins.GetList() {
 		plugin.InitChain(app.state, validators)
 	}
 }
 
-// TMSP::BeginBlock
-func (app *Basecoin) BeginBlock(height uint64) {
+// ABCI::BeginBlock
+func (app *Basecoin) BeginBlock(hash []byte, header *abci.Header) {
 	for _, plugin := range app.plugins.GetList() {
-		plugin.BeginBlock(app.state, height)
+		plugin.BeginBlock(app.state, hash, header)
 	}
 }
 
-// TMSP::EndBlock
-func (app *Basecoin) EndBlock(height uint64) (diffs []*abci.Validator) {
+// ABCI::EndBlock
+func (app *Basecoin) EndBlock(height uint64) (res abci.ResponseEndBlock) {
 	for _, plugin := range app.plugins.GetList() {
-		moreDiffs := plugin.EndBlock(app.state, height)
-		diffs = append(diffs, moreDiffs...)
+		pluginRes := plugin.EndBlock(app.state, height)
+		res.Diffs = append(res.Diffs, pluginRes.Diffs...)
 	}
 	return
 }

--- a/app/app.go
+++ b/app/app.go
@@ -188,3 +188,9 @@ func splitKey(key string) (prefix string, suffix string) {
 	}
 	return key, ""
 }
+
+// (not meant to be called)
+// assert that Basecoin implements `abci.BlockchainAware` at compile-time
+func _assertABCIBlockchainAware(basecoin *Basecoin) abci.BlockchainAware {
+	return basecoin
+}

--- a/plugins/counter/counter.go
+++ b/plugins/counter/counter.go
@@ -93,9 +93,9 @@ func (cp *CounterPlugin) RunTx(store types.KVStore, ctx types.CallContext, txByt
 func (cp *CounterPlugin) InitChain(store types.KVStore, vals []*abci.Validator) {
 }
 
-func (cp *CounterPlugin) BeginBlock(store types.KVStore, height uint64) {
+func (cp *CounterPlugin) BeginBlock(store types.KVStore, hash []byte, header *abci.Header) {
 }
 
-func (cp *CounterPlugin) EndBlock(store types.KVStore, height uint64) []*abci.Validator {
-	return nil
+func (cp *CounterPlugin) EndBlock(store types.KVStore, height uint64) (res abci.ResponseEndBlock) {
+	return
 }

--- a/plugins/ibc/ibc.go
+++ b/plugins/ibc/ibc.go
@@ -374,11 +374,11 @@ func (sm *IBCStateMachine) runPacketPostTx(tx IBCPacketPostTx) {
 func (ibc *IBCPlugin) InitChain(store types.KVStore, vals []*abci.Validator) {
 }
 
-func (ibc *IBCPlugin) BeginBlock(store types.KVStore, height uint64) {
+func (cp *IBCPlugin) BeginBlock(store types.KVStore, hash []byte, header *abci.Header) {
 }
 
-func (ibc *IBCPlugin) EndBlock(store types.KVStore, height uint64) []*abci.Validator {
-	return nil
+func (cp *IBCPlugin) EndBlock(store types.KVStore, height uint64) (res abci.ResponseEndBlock) {
+	return
 }
 
 //--------------------------------------------------------------------------------

--- a/types/plugin.go
+++ b/types/plugin.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+
 	abci "github.com/tendermint/abci/types"
 )
 
@@ -16,8 +17,8 @@ type Plugin interface {
 	// Other ABCI message handlers
 	SetOption(store KVStore, key string, value string) (log string)
 	InitChain(store KVStore, vals []*abci.Validator)
-	BeginBlock(store KVStore, height uint64)
-	EndBlock(store KVStore, height uint64) []*abci.Validator
+	BeginBlock(store KVStore, hash []byte, header *abci.Header)
+	EndBlock(store KVStore, height uint64) abci.ResponseEndBlock
 }
 
 //----------------------------------------


### PR DESCRIPTION
When trying to build a plugin that makes use of `InitChain`/`StartBlock`/`EndBlock`, I found that these methods were not being called. That's because the ABCI interface for these methods had been changed and the Basecoin ABCI app did not implement the `abci.BlockchainAware` interface, so ABCI silently stopped calling these 3 methods. This PR makes changes to properly implement the interface.

Note that the change in this PR breaks the plugin interface, although no existing plugins use these plugins so it should be trivial to upgrade.

Commit c23c01882499a9bbdfd58b334fe924f8862659f5 asserts that we don't silently drop this interface by accident in the future, but I'm not sure if this is a ghetto way to do this.