### PR TITLE
PubKey as string in TxInput json format

### DIFF
--- a/types/pubkey.go
+++ b/types/pubkey.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"encoding/hex"
+	"encoding/json"
+
+	crypto "github.com/tendermint/go-crypto"
+)
+
+/***
+This code is here for demo purposes, I think it belongs in go-common (HexData)
+and go-crypto (JSONPubKey), but easier to review one repo, and get a thumbs up
+or down first.
+***/
+
+type HexData []byte
+
+func (h *HexData) UnmarshalJSON(b []byte) (err error) {
+	// unmarshal into a string
+	var s string
+	err = json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	// and interpret that string as hex
+	bin, err := hex.DecodeString(s)
+	*h = bin
+	return err
+}
+
+func (h HexData) MarshalJSON() ([]byte, error) {
+	s := hex.EncodeToString(h)
+	return json.Marshal(s)
+}
+
+type JSONPubKey struct {
+	crypto.PubKey
+}
+
+func (p *JSONPubKey) UnmarshalJSON(b []byte) error {
+	var data HexData
+	err := data.UnmarshalJSON(b)
+	if err != nil {
+		return err
+	}
+	p.PubKey, err = crypto.PubKeyFromBytes(data)
+	return err
+}
+
+func (p JSONPubKey) MarshalJSON() ([]byte, error) {
+	var data []byte
+	if p.PubKey != nil {
+		data = p.PubKey.Bytes()
+	}
+	return HexData(data).MarshalJSON()
+}

--- a/types/pubkey_test.go
+++ b/types/pubkey_test.go
@@ -1,0 +1,55 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	crypto "github.com/tendermint/go-crypto"
+)
+
+func TestHexData(t *testing.T) {
+	assert := assert.New(t)
+
+	orig := HexData("!@##sdfg")
+	enc, err := json.Marshal(orig)
+	assert.Nil(err)
+
+	var parsed HexData
+	err = json.Unmarshal(enc, &parsed)
+	assert.Nil(err)
+
+	assert.Equal(orig, parsed)
+
+	bin := HexData{79, 3, 72, 4}
+	be, err := json.Marshal(bin)
+	assert.Nil(err)
+	// make sure proper hex
+	assert.Equal(be[0], byte('"'))
+	assert.Equal(be[1], byte('4'))
+	assert.Equal(be[2], byte('f'))
+
+	err = json.Unmarshal(be, &parsed)
+	assert.Nil(err)
+
+	assert.Equal(bin, parsed)
+}
+
+func TestPubKey(t *testing.T) {
+	assert := assert.New(t)
+
+	key := crypto.GenPrivKeyEd25519().PubKey()
+	jkey := JSONPubKey{key}
+	enc, err := json.Marshal(jkey)
+	assert.Nil(err)
+	// see it is nice string (always prefix with byte 1 for ed25519)
+	assert.Equal(enc[0], byte('"'))
+	assert.Equal(enc[1], byte('0'))
+	assert.Equal(enc[2], byte('1'))
+
+	var parsed JSONPubKey
+	err = json.Unmarshal(enc, &parsed)
+	assert.Nil(err)
+
+	assert.Equal(key, parsed.PubKey)
+}


### PR DESCRIPTION
@ebuchman Please review this

As mentioned in slack, I want a more user-friendly format for public keys in json.

In order not to break anything else (which all uses the go-wire json encoding), I use a custom Marshal and Unmarshal function and the standard encoding/json lib.

This allows us to return the public key as a single hex-encoded string to the user.  It is opaque to them anyway, so no need for the funny array format. The first byte of the hex-encoded byte slice is the type byte as always and we use go-wire ReadBinary under the hood to multiplex between different types, to maintain compatibility with existing setups.

I use this in light-client (branch pubkey-json) to expose and parse this new format.

Please give me some feedback here.  The `types/pubkey.go` file may belong in another repo.  Or not.... I figured HexData in go-common and JSONPubKey in go-crypto, but maybe they are just fine here.