### PR TITLE
Signbytes from signed transaction bug fix

### DIFF
--- a/cmd/commands/tx.go
+++ b/cmd/commands/tx.go
@@ -113,7 +113,7 @@ func cmdSendTx(c *cli.Context) error {
 
 	// sign that puppy
 	signBytes := tx.SignBytes(chainID)
-	tx.Inputs[0].Signature = crypto.SignatureS{privKey.Sign(signBytes)}
+	tx.Inputs[0].SignatureS = crypto.SignatureS{privKey.Sign(signBytes)}
 
 	fmt.Println("Signed SendTx:")
 	fmt.Println(string(wire.JSONBytes(tx)))
@@ -169,7 +169,7 @@ func AppTx(c *cli.Context, name string, data []byte) error {
 		Data:  data,
 	}
 
-	tx.Input.Signature = crypto.SignatureS{privKey.Sign(tx.SignBytes(chainID))}
+	tx.Input.SignatureS = crypto.SignatureS{privKey.Sign(tx.SignBytes(chainID))}
 
 	fmt.Println("Signed AppTx:")
 	fmt.Println(string(wire.JSONBytes(tx)))

--- a/plugins/counter/counter_test.go
+++ b/plugins/counter/counter_test.go
@@ -52,7 +52,7 @@ func TestCounterPlugin(t *testing.T) {
 		signBytes := tx.SignBytes(chainID)
 		// t.Logf("Sign bytes: %X\n", signBytes)
 		sig := test1PrivAcc.Sign(signBytes)
-		tx.Input.Signature = crypto.SignatureS{sig}
+		tx.Input.SignatureS = crypto.SignatureS{sig}
 		// t.Logf("Signed TX bytes: %X\n", wire.BinaryBytes(struct{ types.Tx }{tx}))
 
 		// Write request

--- a/state/execution.go
+++ b/state/execution.go
@@ -244,7 +244,7 @@ func validateInputAdvanced(acc *types.Account, signBytes []byte, in types.TxInpu
 		return abci.ErrBaseInsufficientFunds.AppendLog(cmn.Fmt("balance is %v, tried to send %v", balance, in.Coins))
 	}
 	// Check signatures
-	if !acc.PubKey.VerifyBytes(signBytes, in.Signature.Signature) {
+	if !acc.PubKey.VerifyBytes(signBytes, in.SignatureS.Signature) {
 		return abci.ErrBaseInvalidSignature.AppendLog(cmn.Fmt("SignBytes: %X", signBytes))
 	}
 	return abci.OK

--- a/tests/tendermint/main.go
+++ b/tests/tendermint/main.go
@@ -67,7 +67,7 @@ func main() {
 		// Sign request
 		signBytes := tx.SignBytes(chainID)
 		sig := root.Sign(signBytes)
-		tx.Inputs[0].Signature = crypto.SignatureS{sig}
+		tx.Inputs[0].SignatureS = crypto.SignatureS{sig}
 		//fmt.Println("tx:", tx)
 
 		// Write request
@@ -117,7 +117,7 @@ func main() {
 		// Sign request
 		signBytes := tx.SignBytes(chainID)
 		sig := privAccountA.Sign(signBytes)
-		tx.Inputs[0].Signature = crypto.SignatureS{sig}
+		tx.Inputs[0].SignatureS = crypto.SignatureS{sig}
 		//fmt.Println("tx:", tx)
 
 		// Write request

--- a/tests/tmsp/tmsp_test.go
+++ b/tests/tmsp/tmsp_test.go
@@ -50,7 +50,7 @@ func TestSendTx(t *testing.T) {
 	signBytes := tx.SignBytes(chainID)
 	// t.Log("Sign bytes: %X\n", signBytes)
 	sig := test1PrivAcc.Sign(signBytes)
-	tx.Inputs[0].Signature = crypto.SignatureS{sig}
+	tx.Inputs[0].SignatureS = crypto.SignatureS{sig}
 	// t.Log("Signed TX bytes: %X\n", wire.BinaryBytes(types.TxS{tx}))
 
 	// Write request
@@ -102,7 +102,7 @@ func TestSequence(t *testing.T) {
 		// Sign request
 		signBytes := tx.SignBytes(chainID)
 		sig := test1PrivAcc.Sign(signBytes)
-		tx.Inputs[0].Signature = crypto.SignatureS{sig}
+		tx.Inputs[0].SignatureS = crypto.SignatureS{sig}
 		// t.Log("ADDR: %X -> %X\n", tx.Inputs[0].Address, tx.Outputs[0].Address)
 
 		// Write request
@@ -146,7 +146,7 @@ func TestSequence(t *testing.T) {
 		// Sign request
 		signBytes := tx.SignBytes(chainID)
 		sig := privAccountA.Sign(signBytes)
-		tx.Inputs[0].Signature = crypto.SignatureS{sig}
+		tx.Inputs[0].SignatureS = crypto.SignatureS{sig}
 		// t.Log("ADDR: %X -> %X\n", tx.Inputs[0].Address, tx.Outputs[0].Address)
 
 		// Write request

--- a/types/tx.go
+++ b/types/tx.go
@@ -152,7 +152,7 @@ func (tx *SendTx) SignBytes(chainID string) []byte {
 	signBytes := wire.BinaryBytes(chainID)
 	sigz := make([]crypto.Signature, len(tx.Inputs))
 	for i, input := range tx.Inputs {
-		sigz[i] = input.Signature
+		sigz[i] = input.Signature.Signature
 		tx.Inputs[i].Signature.Signature = nil
 	}
 	signBytes = append(signBytes, wire.BinaryBytes(tx)...)

--- a/types/tx.go
+++ b/types/tx.go
@@ -64,11 +64,11 @@ func (p *TxS) UnmarshalJSON(data []byte) (err error) {
 //-----------------------------------------------------------------------------
 
 type TxInput struct {
-	Address   data.Bytes        `json:"address"`   // Hash of the PubKey
-	Coins     Coins             `json:"coins"`     //
-	Sequence  int               `json:"sequence"`  // Must be 1 greater than the last committed TxInput
-	Signature crypto.SignatureS `json:"signature"` // Depends on the PubKey type and the whole Tx
-	PubKey    crypto.PubKeyS    `json:"pub_key"`   // Is present iff Sequence == 0
+	Address    data.Bytes        `json:"address"`   // Hash of the PubKey
+	Coins      Coins             `json:"coins"`     //
+	Sequence   int               `json:"sequence"`  // Must be 1 greater than the last committed TxInput
+	SignatureS crypto.SignatureS `json:"signature"` // Depends on the PubKey type and the whole Tx
+	PubKey     crypto.PubKeyS    `json:"pub_key"`   // Is present iff Sequence == 0
 }
 
 func (txIn TxInput) ValidateBasic() abci.Result {
@@ -94,7 +94,7 @@ func (txIn TxInput) ValidateBasic() abci.Result {
 }
 
 func (txIn TxInput) String() string {
-	return Fmt("TxInput{%X,%v,%v,%v,%v}", txIn.Address, txIn.Coins, txIn.Sequence, txIn.Signature, txIn.PubKey)
+	return Fmt("TxInput{%X,%v,%v,%v,%v}", txIn.Address, txIn.Coins, txIn.Sequence, txIn.SignatureS, txIn.PubKey)
 }
 
 func NewTxInput(pubKey crypto.PubKey, coins Coins, sequence int) TxInput {
@@ -152,12 +152,12 @@ func (tx *SendTx) SignBytes(chainID string) []byte {
 	signBytes := wire.BinaryBytes(chainID)
 	sigz := make([]crypto.Signature, len(tx.Inputs))
 	for i, input := range tx.Inputs {
-		sigz[i] = input.Signature.Signature
-		tx.Inputs[i].Signature.Signature = nil
+		sigz[i] = input.SignatureS.Signature
+		tx.Inputs[i].SignatureS.Signature = nil
 	}
 	signBytes = append(signBytes, wire.BinaryBytes(tx)...)
 	for i := range tx.Inputs {
-		tx.Inputs[i].Signature.Signature = sigz[i]
+		tx.Inputs[i].SignatureS.Signature = sigz[i]
 	}
 	return signBytes
 }
@@ -169,7 +169,7 @@ func (tx *SendTx) SetSignature(addr []byte, sig crypto.Signature) bool {
 	}
 	for i, input := range tx.Inputs {
 		if bytes.Equal(input.Address, addr) {
-			tx.Inputs[i].Signature = sigs
+			tx.Inputs[i].SignatureS = sigs
 			return true
 		}
 	}
@@ -192,10 +192,10 @@ type AppTx struct {
 
 func (tx *AppTx) SignBytes(chainID string) []byte {
 	signBytes := wire.BinaryBytes(chainID)
-	sig := tx.Input.Signature
-	tx.Input.Signature.Signature = nil
+	sig := tx.Input.SignatureS
+	tx.Input.SignatureS.Signature = nil
 	signBytes = append(signBytes, wire.BinaryBytes(tx)...)
-	tx.Input.Signature = sig
+	tx.Input.SignatureS = sig
 	return signBytes
 }
 
@@ -204,7 +204,7 @@ func (tx *AppTx) SetSignature(sig crypto.Signature) bool {
 	if !ok {
 		sigs = crypto.SignatureS{sig}
 	}
-	tx.Input.Signature = sigs
+	tx.Input.SignatureS = sigs
 	return true
 }
 

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -121,5 +121,5 @@ func TestSendTxJSON(t *testing.T) {
 
 	// and make sure the sig is preserved
 	assert.Equal(t, tx, tx2)
-	assert.False(t, tx2.Inputs[0].Signature.Empty())
+	assert.False(t, tx2.Inputs[0].SignatureS.Empty())
 }


### PR DESCRIPTION
Discovery of this bug took place while searching for the cause of an unforgiving, illusive error generated when attempting to sign transaction bytes. After much headache bucky uncovered that if only one transaction input is signed than a valid transaction is returned from PubKey.VerifyBytes (aka a valid signature), however if multiple inputs to a transaction are signed then early signatures are invalidated in process. This bug was never uncovered earlier due to the fact that no other applications where sending in multi-input transactions.

Cause of the bug: In order for a transaction to be validated the transaction must be signed by each input account, Each input account must sign an unsigned version of the transaction. If the transaction has already been signed by other transactions but a new signature needs to be added, the unsigned bytes must be created from a signed signature. This is done by removing all the signatures, getting the unsigned bytes, and then rewriting the existing signatures back onto the transaction. The bug lied here in the process of copying and rewriting the signed bytes, the bytes were not being properly copied, and earlier signatures were vanishing from the transaction when multiple signatures needed to be used. 

This headache is a could have been prevented by using immutable object protocol. 