### PR TITLE
Update install.md to include git pull

### DIFF
--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -13,6 +13,7 @@ the correct way to install is:
 
 ```
 cd $GOPATH/src/github.com/tendermint/basecoin
+git pull origin master
 make get_vendor_deps
 make install
 ```


### PR DESCRIPTION
* Add `git pull origin master` to instructions if you have to run `make get_vendor_deps` and `make install` manually