### PR TITLE
base-cli cleanup

### DIFF
--- a/cmd/basecli/main.go
+++ b/cmd/basecli/main.go
@@ -7,6 +7,7 @@ import (
 	keycmd "github.com/tendermint/go-crypto/cmd"
 	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/light-client/commands/proofs"
+	"github.com/tendermint/light-client/commands/proxy"
 	"github.com/tendermint/light-client/commands/seeds"
 	"github.com/tendermint/light-client/commands/txs"
 	"github.com/tendermint/tmlibs/cli"
@@ -39,6 +40,7 @@ func main() {
 		seeds.RootCmd,
 		proofs.RootCmd,
 		txs.RootCmd,
+		proxy.RootCmd,
 	)
 
 	cmd := cli.PrepareMainCmd(BaseCli, "BC", os.ExpandEnv("$HOME/.basecli"))

--- a/cmd/basecli/main.go
+++ b/cmd/basecli/main.go
@@ -7,7 +7,6 @@ import (
 	keycmd "github.com/tendermint/go-crypto/cmd"
 	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/light-client/commands/proofs"
-	"github.com/tendermint/light-client/commands/proxy"
 	"github.com/tendermint/light-client/commands/seeds"
 	"github.com/tendermint/light-client/commands/txs"
 	"github.com/tendermint/tmlibs/cli"
@@ -25,22 +24,23 @@ tmcli to work for any custom abci app.
 `,
 }
 
-func init() {
+func main() {
 	commands.AddBasicFlags(BaseCli)
 
-	// set up the various commands to use
-	BaseCli.AddCommand(keycmd.RootCmd)
-	BaseCli.AddCommand(commands.InitCmd)
-	BaseCli.AddCommand(seeds.RootCmd)
+	//initialize proofs and txs
 	proofs.StatePresenters.Register("account", AccountPresenter{})
 	proofs.TxPresenters.Register("base", BaseTxPresenter{})
-	BaseCli.AddCommand(proofs.RootCmd)
 	txs.Register("send", SendTxMaker{})
-	BaseCli.AddCommand(txs.RootCmd)
-	BaseCli.AddCommand(proxy.RootCmd)
-}
 
-func main() {
+	// set up the various commands to use
+	BaseCli.AddCommand(
+		keycmd.RootCmd,
+		commands.InitCmd,
+		seeds.RootCmd,
+		proofs.RootCmd,
+		txs.RootCmd,
+	)
+
 	cmd := cli.PrepareMainCmd(BaseCli, "BC", os.ExpandEnv("$HOME/.basecli"))
 	cmd.Execute()
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,7 +44,7 @@ import:
   - rpc/lib/types
   - types
 - package: github.com/tendermint/tmlibs
-  version: develop
+  version: basecoin-cli
   subpackages:
   - cli
   - common

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,7 +44,7 @@ import:
   - rpc/lib/types
   - types
 - package: github.com/tendermint/tmlibs
-  version: basecoin-cli
+  version: develop
   subpackages:
   - cli
   - common


### PR DESCRIPTION
compressed main.go - no global access needed for those commands
referenced state in the key generation to eliminate code dup
added execute with debug