### PR TITLE
Ibc coins

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -150,7 +150,7 @@ func (app *Basecoin) Query(reqQuery abci.RequestQuery) (resQuery abci.ResponseQu
 	// handle special path for account info
 	if reqQuery.Path == "/account" {
 		reqQuery.Path = "/key"
-		reqQuery.Data = sm.AccountKey(reqQuery.Data)
+		reqQuery.Data = types.AccountKey(reqQuery.Data)
 	}
 
 	resQuery, err := app.eyesCli.QuerySync(reqQuery)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	abci "github.com/tendermint/abci/types"
-	"github.com/tendermint/basecoin/state"
 	"github.com/tendermint/basecoin/types"
 	wire "github.com/tendermint/go-wire"
 	eyes "github.com/tendermint/merkleeyes/client"
@@ -38,7 +37,7 @@ func newAppTest(t *testing.T) *appTest {
 
 // make a tx sending 5mycoin from each accIn to accOut
 func (at *appTest) getTx(seq int) *types.SendTx {
-	tx := types.GetTx(seq, at.accOut, at.accIn)
+	tx := types.MakeSendTx(seq, at.accOut, at.accIn)
 	types.SignTx(at.chainID, tx, at.accIn)
 	return tx
 }
@@ -123,7 +122,7 @@ func TestSetOption(t *testing.T) {
 	res = app.SetOption("base/account", string(accsInBytes))
 	require.EqualValues(res, "Success")
 	// make sure it is set correctly, with some balance
-	acct := state.GetAccount(app.GetState(), accIn.PubKey.Address())
+	acct := types.GetAccount(app.GetState(), accIn.PubKey.Address())
 	require.NotNil(acct)
 	assert.Equal(accIn.Balance, acct.Balance)
 
@@ -149,7 +148,7 @@ func TestSetOption(t *testing.T) {
 }`
 	res = app.SetOption("base/account", unsortAcc)
 	require.EqualValues(res, "Success")
-	acct = state.GetAccount(app.GetState(), unsortAddr)
+	acct = types.GetAccount(app.GetState(), unsortAddr)
 	require.NotNil(acct)
 	assert.True(acct.Balance.IsValid())
 	assert.Equal(unsortCoins, acct.Balance)

--- a/cmd/basecli/commands/adapters.go
+++ b/cmd/basecli/commands/adapters.go
@@ -14,7 +14,6 @@ import (
 	"github.com/tendermint/light-client/commands"
 	"github.com/tendermint/light-client/proofs"
 
-	"github.com/tendermint/basecoin/state"
 	btypes "github.com/tendermint/basecoin/types"
 )
 

--- a/cmd/basecli/commands/adapters.go
+++ b/cmd/basecli/commands/adapters.go
@@ -23,7 +23,7 @@ type AccountPresenter struct{}
 func (_ AccountPresenter) MakeKey(str string) ([]byte, error) {
 	res, err := hex.DecodeString(str)
 	if err == nil {
-		res = state.AccountKey(res)
+		res = btypes.AccountKey(res)
 	}
 	return res, err
 }

--- a/cmd/basecoin/main.go
+++ b/cmd/basecoin/main.go
@@ -18,6 +18,7 @@ func main() {
 	RootCmd.AddCommand(
 		commands.InitCmd,
 		commands.StartCmd,
+		commands.RelayCmd,
 		commands.TxCmd,
 		commands.QueryCmd,
 		commands.KeyCmd,

--- a/cmd/commands/ibc.go
+++ b/cmd/commands/ibc.go
@@ -196,13 +196,18 @@ func ibcPacketCreateTxCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	var payload ibc.Payload
+	if err := wire.ReadBinaryBytes(payloadBytes, &payload); err != nil {
+		return err
+	}
+
 	ibcTx := ibc.IBCPacketCreateTx{
 		Packet: ibc.Packet{
 			SrcChainID: fromChain,
 			DstChainID: toChain,
 			Sequence:   sequence,
 			Type:       packetType,
-			Payload:    payloadBytes,
+			Payload:    payload,
 		},
 	}
 

--- a/cmd/commands/query.go
+++ b/cmd/commands/query.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tendermint/go-wire"
 	"github.com/tendermint/merkleeyes/iavl"
+	"github.com/tendermint/tendermint/rpc/client"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
@@ -120,7 +121,8 @@ func accountCmd(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("Account address (%v) is invalid hex: %v\n", addrHex, err)
 	}
 
-	acc, err := getAcc(nodeFlag, addr)
+	httpClient := client.NewHTTP(nodeFlag, "/websocket")
+	acc, err := getAccWithClient(httpClient, addr)
 	if err != nil {
 		return err
 	}

--- a/cmd/commands/relay.go
+++ b/cmd/commands/relay.go
@@ -90,6 +90,11 @@ OUTER:
 			logger.Error("Error parsing sequence number from query", "query.Value", query.Value, "error", err.Error())
 			continue OUTER
 		}
+		seq -= 1 // seq is the packet count. -1 because 0-indexed
+
+		if nextSeq <= int(seq) {
+			logger.Info("Got new packets", "last-sequence", nextSeq-1, "new-sequence", seq)
+		}
 
 		// get all packets since the last one we relayed
 		for ; nextSeq <= int(seq); nextSeq++ {

--- a/cmd/commands/relay.go
+++ b/cmd/commands/relay.go
@@ -1,0 +1,211 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	// 	"github.com/spf13/viper"
+	// 	"github.com/tendermint/tmlibs/cli"
+	// 	"github.com/tendermint/tmlibs/log"
+
+	"github.com/tendermint/go-wire"
+	"github.com/tendermint/merkleeyes/iavl"
+	cmn "github.com/tendermint/tmlibs/common"
+
+	"github.com/tendermint/basecoin/plugins/ibc"
+	"github.com/tendermint/basecoin/types"
+	"github.com/tendermint/tendermint/rpc/client"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+var RelayCmd = &cobra.Command{
+	Use:   "relay",
+	Short: "Start basecoin relayer to relay IBC packets between chains",
+	RunE:  relayCmd,
+}
+
+//flags
+var (
+	chain1AddrFlag string
+	chain2AddrFlag string
+
+	chain1IDFlag string
+	chain2IDFlag string
+
+	fromFileFlag string
+)
+
+func init() {
+
+	flags := []Flag2Register{
+		{&chain1AddrFlag, "chain1-addr", "tcp://localhost:46657", "Node address for chain1"},
+		{&chain2AddrFlag, "chain2-addr", "tcp://localhost:36657", "Node address for chain2"},
+		{&chain1IDFlag, "chain1-id", "test_chain_1", "ChainID for chain1"},
+		{&chain2IDFlag, "chain2-id", "test_chain_2", "ChainID for chain2"},
+		{&fromFileFlag, "from", "key.json", "Path to a private key to sign the transaction"},
+	}
+	RegisterFlags(RelayCmd, flags)
+}
+
+func loop(addr1, addr2, id1, id2 string) {
+	latestSeq := -1
+
+	// load the priv key
+	privKey, err := LoadKey(fromFlag)
+	if err != nil {
+		logger.Error(err.Error())
+		cmn.PanicCrisis(err.Error())
+	}
+
+	// relay from chain1 to chain2
+	thisRelayer := relayer{privKey, id2, addr2}
+
+OUTER:
+	for {
+
+		time.Sleep(time.Second)
+
+		// get the latest ibc packet sequence number
+		key := fmt.Sprintf("ibc,egress,%v,%v", id1, id2)
+		query, err := Query(addr1, []byte(key))
+		if err != nil {
+			logger.Error(err.Error())
+			continue OUTER
+		}
+		seq, err := strconv.ParseUint(string(query.Value), 10, 64)
+		if err != nil {
+			logger.Error(err.Error())
+			continue OUTER
+		}
+
+		// if there's a new packet, relay the header and commit data
+		if latestSeq < int(seq) {
+			header, commit, err := getHeaderAndCommit(addr1, int(query.Height))
+			if err != nil {
+				logger.Error(err.Error())
+				continue OUTER
+			}
+
+			// update the chain state on the other chain
+			ibcTx := ibc.IBCUpdateChainTx{
+				Header: *header,
+				Commit: *commit,
+			}
+			if err := thisRelayer.appTx(ibcTx); err != nil {
+				logger.Error(err.Error())
+				continue OUTER
+			}
+		}
+
+		// get all packets since the last one we relayed
+		for ; latestSeq < int(seq); latestSeq++ {
+			key := fmt.Sprintf("ibc,egress,%v,%v,%d", id1, id2, latestSeq)
+			query, err := Query(addr1, []byte(key))
+			if err != nil {
+				logger.Error(err.Error())
+				continue OUTER
+			}
+
+			var packet ibc.Packet
+			err = wire.ReadBinaryBytes(query.Value, &packet)
+			if err != nil {
+				logger.Error(err.Error())
+				continue OUTER
+			}
+
+			proof := new(iavl.IAVLProof)
+			err = wire.ReadBinaryBytes(query.Proof, proof)
+			if err != nil {
+				logger.Error(err.Error())
+				continue OUTER
+			}
+
+			// relay the packet and proof
+			ibcTx := ibc.IBCPacketPostTx{
+				FromChainID:     id1,
+				FromChainHeight: uint64(query.Height),
+				Packet:          packet,
+				Proof:           proof,
+			}
+			if err := thisRelayer.appTx(ibcTx); err != nil {
+				logger.Error(err.Error())
+				continue OUTER
+			}
+		}
+	}
+}
+
+type relayer struct {
+	privKey  *Key
+	chainID  string
+	nodeAddr string
+}
+
+func (r *relayer) appTx(ibcTx ibc.IBCTx) error {
+	sequence, err := getSeq(r.privKey.Address[:])
+	if err != nil {
+		return err
+	}
+
+	data := []byte(wire.BinaryBytes(struct {
+		ibc.IBCTx `json:"unwrap"`
+	}{ibcTx}))
+
+	input := types.NewTxInput(r.privKey.PubKey, types.Coins{}, sequence)
+	tx := &types.AppTx{
+		Gas:   0,
+		Fee:   types.Coin{"mycoin", 1},
+		Name:  "IBC",
+		Input: input,
+		Data:  data,
+	}
+
+	tx.Input.Signature = r.privKey.Sign(tx.SignBytes(r.chainID))
+	txBytes := []byte(wire.BinaryBytes(struct {
+		types.Tx `json:"unwrap"`
+	}{tx}))
+
+	data, log, err := broadcastTxToNode(r.nodeAddr, txBytes)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Response: %X ; %s\n", data, log)
+	return nil
+}
+
+// broadcast the transaction to tendermint
+func broadcastTxToNode(nodeAddr string, tx tmtypes.Tx) ([]byte, string, error) {
+	httpClient := client.NewHTTP(nodeAddr, "/websocket")
+	res, err := httpClient.BroadcastTxCommit(tx)
+	if err != nil {
+		return nil, "", errors.Errorf("Error on broadcast tx: %v", err)
+	}
+
+	if !res.CheckTx.Code.IsOK() {
+		r := res.CheckTx
+		return nil, "", errors.Errorf("BroadcastTxCommit got non-zero exit code: %v. %X; %s", r.Code, r.Data, r.Log)
+	}
+
+	if !res.DeliverTx.Code.IsOK() {
+		r := res.DeliverTx
+		return nil, "", errors.Errorf("BroadcastTxCommit got non-zero exit code: %v. %X; %s", r.Code, r.Data, r.Log)
+	}
+
+	return res.DeliverTx.Data, res.DeliverTx.Log, nil
+}
+
+func relayCmd(cmd *cobra.Command, args []string) error {
+
+	go loop(chain1AddrFlag, chain2AddrFlag, chain1IDFlag, chain2IDFlag)
+	go loop(chain2AddrFlag, chain1AddrFlag, chain2IDFlag, chain1IDFlag)
+
+	cmn.TrapSignal(func() {
+		// TODO: Cleanup
+	})
+	return nil
+
+}

--- a/cmd/commands/tx.go
+++ b/cmd/commands/tx.go
@@ -220,12 +220,12 @@ func broadcastTx(tx types.Tx) ([]byte, string, error) {
 // if the sequence flag is set, return it;
 // else, fetch the account by querying the app and return the sequence number
 func getSeq(address []byte) (int, error) {
-
 	if seqFlag >= 0 {
 		return seqFlag, nil
 	}
 
-	acc, err := getAcc(txNodeFlag, address)
+	httpClient := client.NewHTTP(txNodeFlag, "/websocket")
+	acc, err := getAccWithClient(httpClient, address)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/commands/tx.go
+++ b/cmd/commands/tx.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -81,10 +82,27 @@ func init() {
 
 func sendTxCmd(cmd *cobra.Command, args []string) error {
 
+	var toHex string
+	var chainPrefix string
+	spl := strings.Split(toFlag, "/")
+	switch len(spl) {
+	case 1:
+		toHex = spl[0]
+	case 2:
+		chainPrefix = spl[0]
+		toHex = spl[1]
+	default:
+		return errors.Errorf("To address has too many slashes")
+	}
+
 	// convert destination address to bytes
-	to, err := hex.DecodeString(StripHex(toFlag))
+	to, err := hex.DecodeString(StripHex(toHex))
 	if err != nil {
 		return errors.Errorf("To address is invalid hex: %v\n", err)
+	}
+
+	if chainPrefix != "" {
+		to = []byte(chainPrefix + "/" + string(to))
 	}
 
 	// load the priv key

--- a/cmd/commands/utils.go
+++ b/cmd/commands/utils.go
@@ -100,6 +100,10 @@ func StripHex(s string) string {
 
 func Query(tmAddr string, key []byte) (*abci.ResultQuery, error) {
 	httpClient := client.NewHTTP(tmAddr, "/websocket")
+	return queryWithClient(httpClient, key)
+}
+
+func queryWithClient(httpClient *client.HTTP, key []byte) (*abci.ResultQuery, error) {
 	res, err := httpClient.ABCIQuery("/key", key, true)
 	if err != nil {
 		return nil, errors.Errorf("Error calling /abci_query: %v", err)
@@ -111,10 +115,10 @@ func Query(tmAddr string, key []byte) (*abci.ResultQuery, error) {
 }
 
 // fetch the account by querying the app
-func getAcc(tmAddr string, address []byte) (*types.Account, error) {
+func getAccWithClient(httpClient *client.HTTP, address []byte) (*types.Account, error) {
 
 	key := types.AccountKey(address)
-	response, err := Query(tmAddr, key)
+	response, err := queryWithClient(httpClient, key)
 	if err != nil {
 		return nil, err
 	}
@@ -145,4 +149,24 @@ func getHeaderAndCommit(tmAddr string, height int) (*tmtypes.Header, *tmtypes.Co
 	commit := res.Commit
 
 	return header, commit, nil
+}
+
+func waitForBlock(httpClient *client.HTTP) error {
+	res, err := httpClient.Status()
+	if err != nil {
+		return err
+	}
+
+	lastHeight := res.LatestBlockHeight
+	for {
+		res, err := httpClient.Status()
+		if err != nil {
+			return err
+		}
+		if res.LatestBlockHeight > lastHeight {
+			break
+		}
+
+	}
+	return nil
 }

--- a/cmd/commands/utils.go
+++ b/cmd/commands/utils.go
@@ -11,7 +11,6 @@ import (
 	abci "github.com/tendermint/abci/types"
 	wire "github.com/tendermint/go-wire"
 
-	"github.com/tendermint/basecoin/state"
 	"github.com/tendermint/basecoin/types"
 
 	client "github.com/tendermint/tendermint/rpc/client"
@@ -114,7 +113,7 @@ func Query(tmAddr string, key []byte) (*abci.ResultQuery, error) {
 // fetch the account by querying the app
 func getAcc(tmAddr string, address []byte) (*types.Account, error) {
 
-	key := state.AccountKey(address)
+	key := types.AccountKey(address)
 	response, err := Query(tmAddr, key)
 	if err != nil {
 		return nil, err

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -123,8 +123,8 @@ echo ""
 echo "... creating egress packet on chain1"
 echo ""
 # create a packet on chain1 destined for chain2
-PAYLOAD="DEADBEEF" #TODO
-basecoin tx ibc --amount 10mycoin $CHAIN_FLAGS1 packet create --ibc_from $CHAIN_ID1 --to $CHAIN_ID2 --type coin --payload $PAYLOAD --ibc_sequence 1
+PAYLOAD="010104DEADBEEF" #TODO
+basecoin tx ibc --amount 10mycoin $CHAIN_FLAGS1 packet create --ibc_from $CHAIN_ID1 --to $CHAIN_ID2 --type coin --payload $PAYLOAD --ibc_sequence 0
 ifExit
 
 echo ""

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -122,16 +122,20 @@ ifExit
 echo ""
 echo "... creating egress packet on chain1"
 echo ""
-# create a packet on chain1 destined for chain2
-PAYLOAD="010104DEADBEEF" #TODO
-basecoin tx ibc --amount 10mycoin $CHAIN_FLAGS1 packet create --ibc_from $CHAIN_ID1 --to $CHAIN_ID2 --type coin --payload $PAYLOAD --ibc_sequence 0
+# send coins from chain1 to an address on chain2
+# TODO: dont hardcode the address
+basecoin tx send --amount 10mycoin $CHAIN_FLAGS1 --to $CHAIN_ID2/053BA0F19616AFF975C8756A2CBFF04F408B4D47 
 ifExit
+
+# alternative way to create packets (for testing)
+# basecoin tx ibc --amount 10mycoin $CHAIN_FLAGS1 packet create --ibc_from $CHAIN_ID1 --to $CHAIN_ID2 --type coin --payload $PAYLOAD --ibc_sequence 0
 
 echo ""
 echo "... querying for packet data"
 echo ""
 # query for the packet data and proof
-QUERY_RESULT=$(basecoin query ibc,egress,$CHAIN_ID1,$CHAIN_ID2,1)
+# since we only sent one packet, the sequence number is 0
+QUERY_RESULT=$(basecoin query ibc,egress,$CHAIN_ID1,$CHAIN_ID2,0)
 ifExit
 HEIGHT=$(echo $QUERY_RESULT | jq .height)
 PACKET=$(echo $QUERY_RESULT | jq .value)
@@ -187,7 +191,7 @@ echo ""
 echo "... checking if the packet is present on chain2"
 echo ""
 # query for the packet on chain2
-basecoin query --node tcp://localhost:36657 ibc,ingress,test_chain_2,test_chain_1,1
+basecoin query --node tcp://localhost:36657 ibc,ingress,test_chain_2,test_chain_1,0
 ifExit
 
 echo ""

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 997e4cc3339141ee01aa2adf656425a49ebf117e6ca9e81ba72b8f94fee3e86e
-updated: 2017-05-17T12:25:00.580569867+02:00
+hash: 9d06ae13959cbb2835f5ae400a4b65e4bc329a567c949aec4aeab318c271da39
+updated: 2017-05-21T21:31:06.796806933-04:00
 imports:
 - name: github.com/bgentry/speakeasy
   version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
@@ -101,7 +101,7 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: github.com/tendermint/abci
-  version: 5dabeffb35c027d7087a12149685daa68989168b
+  version: 864d1f80b36b440bde030a5c18d8ac3aa8c2949d
   subpackages:
   - client
   - example/dummy
@@ -113,7 +113,7 @@ imports:
   - edwards25519
   - extra25519
 - name: github.com/tendermint/go-crypto
-  version: 438b16f1f84ef002d7408ecd6fc3a3974cbc9559
+  version: 7dff40942a64cdeefefa9446b2d104750b349f8a
   subpackages:
   - cmd
   - keys
@@ -122,7 +122,7 @@ imports:
   - keys/server/types
   - keys/storage/filestorage
 - name: github.com/tendermint/go-wire
-  version: 97beaedf0f4dbc035309157c92be3b30cc6e5d74
+  version: 5f88da3dbc1a72844e6dfaf274ce87f851d488eb
   subpackages:
   - data
   - data/base58
@@ -139,13 +139,13 @@ imports:
   - commands/txs
   - proofs
 - name: github.com/tendermint/merkleeyes
-  version: c722818b460381bc5b82e38c73ff6e22a9df624d
+  version: a0e73e1ac3e18e12a007520a4ea2c9822256e307
   subpackages:
   - app
   - client
   - iavl
 - name: github.com/tendermint/tendermint
-  version: 11b5d11e9eec170e1d3dce165f0270d5c0759d69
+  version: 267f134d44e76efb2adef5f0c993da8a5d5bd1b8
   subpackages:
   - blockchain
   - config
@@ -170,7 +170,7 @@ imports:
   - types
   - version
 - name: github.com/tendermint/tmlibs
-  version: 8af1c70a8be17543eb33e9bfbbcdd8371e3201cc
+  version: 306795ae1d8e4f4a10dcc8bdb32a00455843c9d5
   subpackages:
   - autofile
   - cli

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,17 +6,14 @@ import:
 - package: github.com/spf13/pflag
 - package: github.com/spf13/viper
 - package: github.com/tendermint/abci
-  version: develop
   subpackages:
   - server
   - types
 - package: github.com/tendermint/go-crypto
-  version: develop
   subpackages:
   - cmd
   - keys
 - package: github.com/tendermint/go-wire
-  version: develop
   subpackages:
   - data
 - package: github.com/tendermint/light-client
@@ -28,7 +25,6 @@ import:
   - commands/txs
   - proofs
 - package: github.com/tendermint/merkleeyes
-  version: develop
   subpackages:
   - client
   - iavl
@@ -44,7 +40,6 @@ import:
   - rpc/lib/types
   - types
 - package: github.com/tendermint/tmlibs
-  version: develop
   subpackages:
   - cli
   - common

--- a/plugins/ibc/ibc.go
+++ b/plugins/ibc/ibc.go
@@ -69,7 +69,9 @@ func NewPacket(src, dst string, seq uint64, payload Payload) Packet {
 	}
 }
 
-// GetSequenceNumber gets the sequence number for packets being sent from the src chain to the dst chain
+// GetSequenceNumber gets the sequence number for packets being sent from the src chain to the dst chain.
+// The sequence number counts how many packets have been sent.
+// The next packet must include the latest sequence number.
 func GetSequenceNumber(store types.KVStore, src, dst string) uint64 {
 	sequenceKey := toKey(_IBC, _EGRESS, src, dst)
 	seqBytes := store.Get(sequenceKey)

--- a/plugins/ibc/ibc.go
+++ b/plugins/ibc/ibc.go
@@ -59,6 +59,16 @@ type Packet struct {
 	Payload    Payload
 }
 
+func NewPacket(src, dst string, seq uint64, ty string, payload Payload) Packet {
+	return Packet{
+		SrcChainID: src,
+		DstChainID: dst,
+		Sequence:   seq,
+		Type:       ty,
+		Payload:    payload,
+	}
+}
+
 //--------------------------------------------------------------------------------
 
 const (

--- a/plugins/ibc/ibc.go
+++ b/plugins/ibc/ibc.go
@@ -433,6 +433,9 @@ func (sm *IBCStateMachine) runPacketPostTx(tx IBCPacketPostTx) {
 	case CoinsPayload:
 		// Add coins to destination account
 		acc := bcsm.GetAccount(sm.store, payload.Address)
+		if acc == nil {
+			acc = &types.Account{}
+		}
 		acc.Balance = acc.Balance.Plus(payload.Coins)
 		bcsm.SetAccount(sm.store, payload.Address, acc)
 	}

--- a/plugins/ibc/ibc.go
+++ b/plugins/ibc/ibc.go
@@ -418,6 +418,9 @@ func (sm *IBCStateMachine) runPacketCreateTx(tx IBCPacketCreateTx) {
 
 	// Save new Packet
 	save(sm.store, packetKey, packet)
+
+	// set the sequence number
+	SetSequenceNumber(sm.store, packet.SrcChainID, packet.DstChainID, packet.Sequence)
 }
 
 func (sm *IBCStateMachine) runPacketPostTx(tx IBCPacketPostTx) {
@@ -473,7 +476,7 @@ func (sm *IBCStateMachine) runPacketPostTx(tx IBCPacketPostTx) {
 	ok := proof.Verify(packetKeyEgress, packetBytes, header.AppHash)
 	if !ok {
 		sm.res.Code = IBCCodeInvalidProof
-		sm.res.Log = "Proof is invalid"
+		sm.res.Log = fmt.Sprintf("Proof is invalid. key: %s; packetByes %X; header %v; proof %v", packetKeyEgress, packetBytes, header, proof)
 		return
 	}
 

--- a/plugins/ibc/ibc.go
+++ b/plugins/ibc/ibc.go
@@ -102,6 +102,15 @@ func SaveNewIBCPacket(state types.KVStore, src, dst string, payload Payload) {
 	save(state, packetKey, packet)
 }
 
+func GetIBCPacket(state types.KVStore, src, dst string, seq uint64) (Packet, error) {
+	packetKey := toKey(_IBC, _EGRESS, src, dst, cmn.Fmt("%v", seq))
+	packetBytes := state.Get(packetKey)
+
+	var packet Packet
+	err := wire.ReadBinaryBytes(packetBytes, &packet)
+	return packet, err
+}
+
 //--------------------------------------------------------------------------------
 
 const (

--- a/plugins/ibc/ibc_test.go
+++ b/plugins/ibc/ibc_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/tendermint/merkleeyes/iavl"
 	cmn "github.com/tendermint/tmlibs/common"
 
-	sm "github.com/tendermint/basecoin/state"
 	"github.com/tendermint/basecoin/types"
 	tm "github.com/tendermint/tendermint/types"
 )
@@ -170,7 +169,7 @@ func TestIBCPluginPost(t *testing.T) {
 	registerChain(t, ibcPlugin, store, ctx, "test_chain", string(genDocJSON_1))
 
 	// Create a new packet (for testing)
-	packet := NewPacket("test_chain", "dst_chain", 0, "data", BytesPayload([]byte("hello world")))
+	packet := NewPacket("test_chain", "dst_chain", 0, DataPayload([]byte("hello world")))
 	res := ibcPlugin.RunTx(store, ctx, wire.BinaryBytes(struct{ IBCTx }{IBCPacketCreateTx{
 		Packet: packet,
 	}}))
@@ -203,7 +202,7 @@ func TestIBCPluginPayloadBytes(t *testing.T) {
 	registerChain(t, ibcPlugin, store, ctx, "test_chain", string(genDocJSON_1))
 
 	// Create a new packet (for testing)
-	packet := NewPacket("test_chain", "dst_chain", 0, "data", BytesPayload([]byte("hello world")))
+	packet := NewPacket("test_chain", "dst_chain", 0, DataPayload([]byte("hello world")))
 	res := ibcPlugin.RunTx(store, ctx, wire.BinaryBytes(struct{ IBCTx }{IBCPacketCreateTx{
 		Packet: packet,
 	}}))
@@ -282,7 +281,7 @@ func TestIBCPluginPayloadCoins(t *testing.T) {
 	coinsGood := types.Coins{types.Coin{"mycoin", 1}}
 
 	// Try to send too many coins
-	packet := NewPacket("test_chain", "dst_chain", 0, "data", CoinsPayload{
+	packet := NewPacket("test_chain", "dst_chain", 0, CoinsPayload{
 		Address: destinationAddr,
 		Coins:   coinsBad,
 	})
@@ -292,7 +291,7 @@ func TestIBCPluginPayloadCoins(t *testing.T) {
 	assertAndLog(t, store, res, abci.CodeType_InsufficientFunds)
 
 	// Send a small enough number of coins
-	packet = NewPacket("test_chain", "dst_chain", 0, "data", CoinsPayload{
+	packet = NewPacket("test_chain", "dst_chain", 0, CoinsPayload{
 		Address: destinationAddr,
 		Coins:   coinsGood,
 	})
@@ -334,7 +333,7 @@ func TestIBCPluginPayloadCoins(t *testing.T) {
 	assert.Nil(err)
 
 	// Account should be empty before the tx
-	acc := sm.GetAccount(store, destinationAddr)
+	acc := types.GetAccount(store, destinationAddr)
 	assert.Nil(acc)
 
 	// Post a packet
@@ -347,7 +346,7 @@ func TestIBCPluginPayloadCoins(t *testing.T) {
 	assertAndLog(t, store, res, abci.CodeType_OK)
 
 	// Account should now have some coins
-	acc = sm.GetAccount(store, destinationAddr)
+	acc = types.GetAccount(store, destinationAddr)
 	assert.Equal(acc.Balance, coinsGood)
 }
 
@@ -408,7 +407,7 @@ func TestIBCPluginBadProof(t *testing.T) {
 	registerChain(t, ibcPlugin, store, ctx, "test_chain", string(genDocJSON_1))
 
 	// Create a new packet (for testing)
-	packet := NewPacket("test_chain", "dst_chain", 0, "data", BytesPayload([]byte("hello world")))
+	packet := NewPacket("test_chain", "dst_chain", 0, DataPayload([]byte("hello world")))
 	res := ibcPlugin.RunTx(store, ctx, wire.BinaryBytes(struct{ IBCTx }{IBCPacketCreateTx{
 		Packet: packet,
 	}}))

--- a/state/state.go
+++ b/state/state.go
@@ -3,9 +3,7 @@ package state
 import (
 	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/basecoin/types"
-	wire "github.com/tendermint/go-wire"
 	eyes "github.com/tendermint/merkleeyes/client"
-	. "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 )
 
@@ -64,11 +62,11 @@ func (s *State) Set(key []byte, value []byte) {
 }
 
 func (s *State) GetAccount(addr []byte) *types.Account {
-	return GetAccount(s, addr)
+	return types.GetAccount(s, addr)
 }
 
 func (s *State) SetAccount(addr []byte, acc *types.Account) {
-	SetAccount(s, addr, acc)
+	types.SetAccount(s, addr, acc)
 }
 
 func (s *State) CacheWrap() *State {
@@ -96,29 +94,4 @@ func (s *State) Commit() abci.Result {
 		return abci.NewError(abci.CodeType_InternalError, "can only use Commit if store is merkleeyes")
 	}
 
-}
-
-//----------------------------------------
-
-func AccountKey(addr []byte) []byte {
-	return append([]byte("base/a/"), addr...)
-}
-
-func GetAccount(store types.KVStore, addr []byte) *types.Account {
-	data := store.Get(AccountKey(addr))
-	if len(data) == 0 {
-		return nil
-	}
-	var acc *types.Account
-	err := wire.ReadBinaryBytes(data, &acc)
-	if err != nil {
-		panic(Fmt("Error reading account %X error: %v",
-			data, err.Error()))
-	}
-	return acc
-}
-
-func SetAccount(store types.KVStore, addr []byte, acc *types.Account) {
-	accBytes := wire.BinaryBytes(acc)
-	store.Set(AccountKey(addr), accBytes)
 }

--- a/types/account.go
+++ b/types/account.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/tendermint/go-crypto"
+	"github.com/tendermint/go-wire"
 )
 
 type Account struct {
@@ -48,4 +49,27 @@ type AccountSetter interface {
 type AccountGetterSetter interface {
 	GetAccount(addr []byte) *Account
 	SetAccount(addr []byte, acc *Account)
+}
+
+func AccountKey(addr []byte) []byte {
+	return append([]byte("base/a/"), addr...)
+}
+
+func GetAccount(store KVStore, addr []byte) *Account {
+	data := store.Get(AccountKey(addr))
+	if len(data) == 0 {
+		return nil
+	}
+	var acc *Account
+	err := wire.ReadBinaryBytes(data, &acc)
+	if err != nil {
+		panic(fmt.Sprintf("Error reading account %X error: %v",
+			data, err.Error()))
+	}
+	return acc
+}
+
+func SetAccount(store KVStore, addr []byte, acc *Account) {
+	accBytes := wire.BinaryBytes(acc)
+	store.Set(AccountKey(addr), accBytes)
 }

--- a/types/test_helpers.go
+++ b/types/test_helpers.go
@@ -86,15 +86,15 @@ func Accs2TxOutputs(accs ...PrivAccount) []TxOutput {
 	return txs
 }
 
-func GetTx(seq int, accOut PrivAccount, accsIn ...PrivAccount) *SendTx {
-	txs := &SendTx{
+func MakeSendTx(seq int, accOut PrivAccount, accsIn ...PrivAccount) *SendTx {
+	tx := &SendTx{
 		Gas:     0,
 		Fee:     Coin{"mycoin", 1},
 		Inputs:  Accs2TxInputs(seq, accsIn...),
 		Outputs: Accs2TxOutputs(accOut),
 	}
 
-	return txs
+	return tx
 }
 
 func SignTx(chainID string, tx *SendTx, accs ...PrivAccount) {

--- a/types/tx.go
+++ b/types/tx.go
@@ -116,10 +116,33 @@ type TxOutput struct {
 	Coins   Coins      `json:"coins"`   //
 }
 
-func (txOut TxOutput) ValidateBasic() abci.Result {
-	if len(txOut.Address) != 20 {
-		return abci.ErrBaseInvalidOutput.AppendLog("Invalid address length")
+// An output destined for another chain may be formatted as `chainID/address`.
+// ChainAndAddress returns the chainID prefix and the address.
+// If there is no chainID prefix, the first returned value is nil.
+func (txOut TxOutput) ChainAndAddress() ([]byte, []byte, abci.Result) {
+	var chainPrefix []byte
+	address := txOut.Address
+	if len(address) > 20 {
+		spl := bytes.Split(address, []byte("/"))
+		if len(spl) < 2 {
+			return nil, nil, abci.ErrBaseInvalidOutput.AppendLog("Invalid address format")
+		}
+		chainPrefix = spl[0]
+		address = bytes.Join(spl[1:], nil)
 	}
+
+	if len(address) != 20 {
+		return nil, nil, abci.ErrBaseInvalidOutput.AppendLog("Invalid address length")
+	}
+	return chainPrefix, address, abci.OK
+}
+
+func (txOut TxOutput) ValidateBasic() abci.Result {
+	_, _, r := txOut.ChainAndAddress()
+	if r.IsErr() {
+		return r
+	}
+
 	if !txOut.Coins.IsValid() {
 		return abci.ErrBaseInvalidOutput.AppendLog(Fmt("Invalid coins %v", txOut.Coins))
 	}


### PR DESCRIPTION
- Support SendTx to other chains with addresses like `test_chain_2/deadbeef`
- Add new `basecoin relay` command for relaying IBC packets between chains

The relayer could probably use more work as currently it just connects to one node from each chain. If that node goes down the relayer is stuck. 