### PR TITLE
reorganize basecli appTx commands

### DIFF
--- a/cmd/basecli/counter/query.go
+++ b/cmd/basecli/counter/query.go
@@ -8,13 +8,14 @@ import (
 	"github.com/tendermint/basecoin/plugins/counter"
 )
 
+//CounterQueryCmd CLI command to query the counter state
 var CounterQueryCmd = &cobra.Command{
 	Use:   "counter",
 	Short: "Query counter state, with proof",
-	RunE:  doCounterQuery,
+	RunE:  counterQueryCmd,
 }
 
-func doCounterQuery(cmd *cobra.Command, args []string) error {
+func counterQueryCmd(cmd *cobra.Command, args []string) error {
 	key := counter.New().StateKey()
 
 	var cp counter.CounterPluginState
@@ -25,18 +26,3 @@ func doCounterQuery(cmd *cobra.Command, args []string) error {
 
 	return proofcmd.OutputProof(cp, proof.BlockHeight())
 }
-
-/*** doesn't seem to be needed anymore??? ***/
-
-// type CounterPresenter struct{}
-
-// func (_ CounterPresenter) MakeKey(str string) ([]byte, error) {
-//   key := counter.New().StateKey()
-//   return key, nil
-// }
-
-// func (_ CounterPresenter) ParseData(raw []byte) (interface{}, error) {
-//   var cp counter.CounterPluginState
-//   err := wire.ReadBinaryBytes(raw, &cp)
-//   return cp, err
-// }

--- a/cmd/basecli/main.go
+++ b/cmd/basecli/main.go
@@ -32,26 +32,25 @@ tmcli to work for any custom abci app.
 func main() {
 	commands.AddBasicFlags(BaseCli)
 
-	// prepare queries
+	// Prepare queries
 	pr := proofs.RootCmd
-	// these are default parsers, but you optional in your app
+	// These are default parsers, but you optional in your app
 	pr.AddCommand(proofs.TxCmd)
 	pr.AddCommand(proofs.KeyCmd)
 	pr.AddCommand(bcmd.AccountQueryCmd)
 	pr.AddCommand(bcount.CounterQueryCmd)
 
-	// here is how you would add the custom txs... but don't really add demo in your app
+	// Here is how you add custom txs... but don't really add counter in your app
 	proofs.TxPresenters.Register("base", bcmd.BaseTxPresenter{})
 	tr := txs.RootCmd
 	tr.AddCommand(bcmd.SendTxCmd)
 	tr.AddCommand(bcount.CounterTxCmd)
 
 	// TODO
-
 	// txs.Register("send", bcmd.SendTxMaker{})
 	// txs.Register("counter", bcount.CounterTxMaker{})
 
-	// set up the various commands to use
+	// Set up the various commands to use
 	BaseCli.AddCommand(
 		commands.InitCmd,
 		commands.ResetCmd,


### PR DESCRIPTION
I wanted to make the process flow a bit more clear when generating a new AppTx transaction. Rather than passing around an `AppTx` struct to be have flags directly inserted into it, flags are parsed and fed to back up to the custom plugin app-tx command and then added to an `AppTx` struct as it's created. 

Additionally a few more commands that an plugin will typically not need to consider when developing the appTx have been clumped together and exported to the bcmd command (`BroadcastTx`)

Lastly, one nuance implication of these changes is they are more conducive to more complex multi-transaction commands which a developer may wish to implement. The common flags can be pulled as variables and applied to multiple transactions this way instead of needing to cross reference the previous transaction which appTx flags were pulled into. 