### PR TITLE
WIP: #106 wrong height on restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ test_cli: tests/cli/shunit2
 	# sudo apt-get install jq
 	@./tests/cli/basictx.sh
 	@./tests/cli/counter.sh
+	@./tests/cli/restart.sh
 	@./tests/cli/ibc.sh
 
 get_vendor_deps: tools

--- a/app/app.go
+++ b/app/app.go
@@ -8,7 +8,7 @@ import (
 	abci "github.com/tendermint/abci/types"
 	wire "github.com/tendermint/go-wire"
 	eyes "github.com/tendermint/merkleeyes/client"
-	. "github.com/tendermint/tmlibs/common"
+	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
 
 	sm "github.com/tendermint/basecoin/state"
@@ -53,7 +53,15 @@ func (app *Basecoin) GetState() *sm.State {
 
 // ABCI::Info
 func (app *Basecoin) Info() abci.ResponseInfo {
-	return abci.ResponseInfo{Data: Fmt("Basecoin v%v", version.Version)}
+	resp, err := app.eyesCli.InfoSync()
+	if err != nil {
+		cmn.PanicCrisis(err)
+	}
+	return abci.ResponseInfo{
+		Data:             cmn.Fmt("Basecoin v%v", version.Version),
+		LastBlockHeight:  resp.LastBlockHeight,
+		LastBlockAppHash: resp.LastBlockAppHash,
+	}
 }
 
 func (app *Basecoin) RegisterPlugin(plugin types.Plugin) {
@@ -172,7 +180,7 @@ func (app *Basecoin) Commit() (res abci.Result) {
 	app.cacheState = app.state.CacheWrap()
 
 	if res.IsErr() {
-		PanicSanity("Error getting hash: " + res.Error())
+		cmn.PanicSanity("Error getting hash: " + res.Error())
 	}
 	return res
 }

--- a/glide.lock
+++ b/glide.lock
@@ -139,7 +139,7 @@ imports:
   - commands/txs
   - proofs
 - name: github.com/tendermint/merkleeyes
-  version: feb2c3fadac8221f96fbfce65a63af034327f972
+  version: 5df9e851e1af64b4fbc7ecab89a9735010ed30fa
   subpackages:
   - app
   - client

--- a/tests/cli/common.sh
+++ b/tests/cli/common.sh
@@ -77,7 +77,7 @@ initServer() {
   return $?
 }
 
-# usage: startServer SERVE_DIR SERVER_LOG
+# XXX Ex Usage: startServer $SERVE_DIR $SERVER_LOG
 startServer() {
   ${SERVER_EXE} start --home=$1 >>$2 2>&1 &
   sleep 5
@@ -88,13 +88,6 @@ startServer() {
     cat $SERVER_LOG
     return 1
   fi
-}
-
-# XXX Ex Usage: stopServer $PID_SERVER
-stopServer() {
-  echo "stopping $SERVER_EXE test server..."
-  kill -9 $1 >/dev/null 2>&1
-  sleep 1
 }
 
 # XXX Ex Usage1: initClient $CHAINID

--- a/tests/cli/restart.sh
+++ b/tests/cli/restart.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# these are two globals to control all scripts (can use eg. counter instead)
+SERVER_EXE=basecoin
+CLIENT_EXE=basecli
+
+oneTimeSetUp() {
+  # these are passed in as args
+  BASE_DIR=$HOME/.basecoin_test_restart
+  CHAIN_ID=restart-chain
+
+  rm -rf $BASE_DIR 2>/dev/null
+  mkdir -p $BASE_DIR
+
+  # set up client - make sure you use the proper prefix if you set
+  # a custom CLIENT_EXE
+  export BC_HOME=${BASE_DIR}/client
+  prepareClient
+
+  # start basecoin server (with counter)
+  initServer $BASE_DIR $CHAIN_ID 3456
+  if [ $? != 0 ]; then return 1; fi
+
+  initClient $CHAIN_ID 34567
+
+  echo "...Testing may begin!"
+  echo
+  echo
+  echo
+}
+
+oneTimeTearDown() {
+  echo
+  echo
+  stopServer $PID_SERVER
+}
+
+test00PreRestart() {
+  SENDER=$(getAddr $RICH)
+  RECV=$(getAddr $POOR)
+
+  RES=$(echo qwertyuiop | ${CLIENT_EXE} tx send --amount=992mycoin --sequence=1 --to=$RECV --name=$RICH 2>/dev/null)
+  txSucceeded $? "$RES"
+  TX=`echo $RES | cut -d: -f2-`
+  HASH=$(echo $TX | jq .hash | tr -d \")
+  TX_HEIGHT=$(echo $TX | jq .height)
+
+  checkAccount $SENDER "1" "9007199254740000"
+  checkAccount $RECV "0" "992"
+
+  # make sure tx is indexed
+  checkSendTx $HASH $TX_HEIGHT $SENDER "992"
+
+}
+
+
+test01OnRestart() {
+  SENDER=$(getAddr $RICH)
+  RECV=$(getAddr $POOR)
+
+  RES=$(echo qwertyuiop | ${CLIENT_EXE} tx send --amount=10000mycoin --sequence=2 --to=$RECV --name=$RICH 2>/dev/null)
+  txSucceeded $? "$RES"
+  if [ $? != 0 ]; then echo "can't make tx!"; return 1; fi
+
+  TX=`echo $RES | cut -d: -f2-`
+  HASH=$(echo $TX | jq .hash | tr -d \")
+  TX_HEIGHT=$(echo $TX | jq .height)
+
+  # wait til we have quite a few blocks... like at least 20,
+  # so the query command won't just wait for the next eg. 7 blocks to verify the result
+  echo "waiting to generate lots of blocks..."
+  sleep 20
+  echo "done waiting!"
+
+  # last minute tx just at the block cut-off...
+  RES=$(echo qwertyuiop | ${CLIENT_EXE} tx send --amount=20000mycoin --sequence=3 --to=$RECV --name=$RICH 2>/dev/null)
+  txSucceeded $? "$RES"
+  if [ $? != 0 ]; then echo "can't make second tx!"; return 1; fi
+
+  # now we do a restart...
+  stopServer $PID_SERVER
+  startServer $BASE_DIR/server $BASE_DIR/${SERVER_EXE}.log
+  if [ $? != 0 ]; then echo "can't restart server!"; return 1; fi
+
+  # make sure queries still work properly, with all 3 tx now executed
+  checkAccount $SENDER "3" "9007199254710000"
+  checkAccount $RECV "0" "30992"
+
+  # make sure tx is indexed
+  checkSendTx $HASH $TX_HEIGHT $SENDER "10000"
+
+  # for double-check of logs
+  if [ -n "$DEBUG" ]; then
+    cat $BASE_DIR/${SERVER_EXE}.log;
+  fi
+}
+
+
+# load and run these tests with shunit2!
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" #get this files directory
+
+# load common helpers
+. $DIR/common.sh
+
+. $DIR/shunit2
+

--- a/tests/cli/restart.sh
+++ b/tests/cli/restart.sh
@@ -3,36 +3,16 @@
 # these are two globals to control all scripts (can use eg. counter instead)
 SERVER_EXE=basecoin
 CLIENT_EXE=basecli
+ACCOUNTS=(jae ethan bucky rigel igor)
+RICH=${ACCOUNTS[0]}
+POOR=${ACCOUNTS[4]}
 
 oneTimeSetUp() {
-  # these are passed in as args
-  BASE_DIR=$HOME/.basecoin_test_restart
-  CHAIN_ID=restart-chain
-
-  rm -rf $BASE_DIR 2>/dev/null
-  mkdir -p $BASE_DIR
-
-  # set up client - make sure you use the proper prefix if you set
-  # a custom CLIENT_EXE
-  export BC_HOME=${BASE_DIR}/client
-  prepareClient
-
-  # start basecoin server (with counter)
-  initServer $BASE_DIR $CHAIN_ID 3456
-  if [ $? != 0 ]; then return 1; fi
-
-  initClient $CHAIN_ID 34567
-
-  echo "...Testing may begin!"
-  echo
-  echo
-  echo
+  quickSetup .basecoin_test_restart restart-chain
 }
 
 oneTimeTearDown() {
-  echo
-  echo
-  stopServer $PID_SERVER
+  quickTearDown
 }
 
 test00PreRestart() {
@@ -52,7 +32,6 @@ test00PreRestart() {
   checkSendTx $HASH $TX_HEIGHT $SENDER "992"
 
 }
-
 
 test01OnRestart() {
   SENDER=$(getAddr $RICH)
@@ -78,11 +57,12 @@ test01OnRestart() {
   if [ $? != 0 ]; then echo "can't make second tx!"; return 1; fi
 
   # now we do a restart...
-  stopServer $PID_SERVER
+  quickTearDown
   startServer $BASE_DIR/server $BASE_DIR/${SERVER_EXE}.log
   if [ $? != 0 ]; then echo "can't restart server!"; return 1; fi
 
   # make sure queries still work properly, with all 3 tx now executed
+  echo "Checking state after restart..."
   checkAccount $SENDER "3" "9007199254710000"
   checkAccount $RECV "0" "30992"
 

--- a/tests/cli/restart.sh
+++ b/tests/cli/restart.sh
@@ -69,7 +69,7 @@ test01OnRestart() {
   # wait til we have quite a few blocks... like at least 20,
   # so the query command won't just wait for the next eg. 7 blocks to verify the result
   echo "waiting to generate lots of blocks..."
-  sleep 20
+  sleep 5
   echo "done waiting!"
 
   # last minute tx just at the block cut-off...


### PR DESCRIPTION
This branch is an attempt to address the problem that all heights are off after the restart, and thus the light-client cannot make a decent proof.

There was a purported fix in `merkleeyes:fix-restart-height`, this PR adds a cli test to demonstrate the problem, and updates the glide dependencies to the most recent version of that branch.

When all tests pass and the merkleeyes branch is merged into develop, then this will be ready to merge.

To see the test issue, check out this branch, and try the following.

```
make all
DEBUG=1 ./tests/cli/restart.sh
```

`make all` updates all dependencies, compiles the binaries and runs all tests.  Assuming this fails, run the second command to get more debug output on fixing the restart test.  Notably the output of the basecoin server log.