### PR TITLE
Add Signers in ReadAppTxFlags

### DIFF
--- a/cmd/basecli/commands/apptx.go
+++ b/cmd/basecli/commands/apptx.go
@@ -10,6 +10,7 @@ import (
 	bc "github.com/tendermint/basecoin/types"
 )
 
+// AppTx Application transaction structure for client
 type AppTx struct {
 	chainID string
 	signers []crypto.PubKey
@@ -56,23 +57,6 @@ func (s *AppTx) TxBytes() ([]byte, error) {
 	// How many times have I lost an hour over this trick?!
 	txBytes := wire.BinaryBytes(bc.TxS{s.Tx})
 	return txBytes, nil
-}
-
-// AddSigner sets address and pubkey info on the tx based on the key that
-// will be used for signing
-func (a *AppTx) AddSigner(pk crypto.PubKey) {
-	// get addr if available
-	var addr []byte
-	if !pk.Empty() {
-		addr = pk.Address()
-	}
-
-	// set the send address, and pubkey if needed
-	in := &a.Tx.Input
-	in.Address = addr
-	if in.Sequence == 1 {
-		in.PubKey = pk
-	}
 }
 
 // TODO: this should really be in the basecoin.types SendTx,


### PR DESCRIPTION
I feel like the refactor from this structural change should maybe extend to sendTx - also maybe to the `SignAndPostTx` function in light client - like maybe we shouldn't need to wrap the Tx before sending here. gtg now but maybe we can discuss these changes and group in with this PR