### PR TITLE
Implement fee handling with IPC

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tendermint/basecoin/modules/auth"
 	"github.com/tendermint/basecoin/modules/base"
 	"github.com/tendermint/basecoin/modules/coin"
+	"github.com/tendermint/basecoin/modules/fee"
 	"github.com/tendermint/basecoin/stack"
 	sm "github.com/tendermint/basecoin/state"
 	"github.com/tendermint/basecoin/version"
@@ -52,7 +53,7 @@ func NewBasecoin(handler basecoin.Handler, eyesCli *eyes.Client, logger log.Logg
 }
 
 // DefaultHandler - placeholder to just handle sendtx
-func DefaultHandler() basecoin.Handler {
+func DefaultHandler(feeDenom string) basecoin.Handler {
 	// use the default stack
 	h := coin.NewHandler()
 	d := stack.NewDispatcher(stack.WrapHandler(h))
@@ -61,6 +62,7 @@ func DefaultHandler() basecoin.Handler {
 		stack.Recovery{},
 		auth.Signatures{},
 		base.Chain{},
+		fee.NewSimpleFeeMiddleware(coin.Coin{feeDenom, 0}, fee.Bank),
 	).Use(d)
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tendermint/basecoin/modules/auth"
 	"github.com/tendermint/basecoin/modules/base"
 	"github.com/tendermint/basecoin/modules/coin"
+	"github.com/tendermint/basecoin/modules/fee"
 	"github.com/tendermint/basecoin/stack"
 	"github.com/tendermint/basecoin/state"
 	wire "github.com/tendermint/go-wire"
@@ -40,15 +41,31 @@ func newAppTest(t *testing.T) *appTest {
 	return at
 }
 
-// make a tx sending 5mycoin from each acctIn to acctOut
-func (at *appTest) getTx(coins coin.Coins) basecoin.Tx {
+// baseTx is the
+func (at *appTest) baseTx(coins coin.Coins) basecoin.Tx {
 	in := []coin.TxInput{{Address: at.acctIn.Actor(), Coins: coins}}
 	out := []coin.TxOutput{{Address: at.acctOut.Actor(), Coins: coins}}
 	tx := coin.NewSendTx(in, out)
-	tx = base.NewChainTx(at.chainID, 0, tx)
+	return tx
+}
+
+func (at *appTest) signTx(tx basecoin.Tx) basecoin.Tx {
 	stx := auth.NewMulti(tx)
 	auth.Sign(stx, at.acctIn.Key)
 	return stx.Wrap()
+}
+
+func (at *appTest) getTx(coins coin.Coins) basecoin.Tx {
+	tx := at.baseTx(coins)
+	tx = base.NewChainTx(at.chainID, 0, tx)
+	return at.signTx(tx)
+}
+
+func (at *appTest) feeTx(coins coin.Coins, toll coin.Coin) basecoin.Tx {
+	tx := at.baseTx(coins)
+	tx = fee.NewFee(tx, toll, at.acctIn.Actor())
+	tx = base.NewChainTx(at.chainID, 0, tx)
+	return at.signTx(tx)
 }
 
 // set the account on the app through SetOption
@@ -67,7 +84,7 @@ func (at *appTest) reset() {
 	logger := log.NewTMLogger(os.Stdout).With("module", "app")
 	logger = log.NewTracingLogger(logger)
 	at.app = NewBasecoin(
-		DefaultHandler(),
+		DefaultHandler("mycoin"),
 		eyesCli,
 		logger,
 	)
@@ -124,7 +141,7 @@ func TestSetOption(t *testing.T) {
 
 	eyesCli := eyes.NewLocalClient("", 0)
 	app := NewBasecoin(
-		DefaultHandler(),
+		DefaultHandler("atom"),
 		eyesCli,
 		log.TestingLogger().With("module", "app"),
 	)
@@ -212,6 +229,17 @@ func TestTx(t *testing.T) {
 	assert.True(res.IsOK(), "ExecTx/Good DeliverTx: Expected OK return from ExecTx, Error: %v", res)
 	assert.Equal(amt.Negative(), diffIn)
 	assert.Equal(amt, diffOut)
+
+	//DeliverTx with fee.... 4 get to recipient, 1 extra taxed
+	at.reset()
+	amt = coin.Coins{{"mycoin", 4}}
+	toll := coin.Coin{"mycoin", 1}
+	res, diffIn, diffOut = at.exec(t, at.feeTx(amt, toll), false)
+	assert.True(res.IsOK(), "ExecTx/Good DeliverTx: Expected OK return from ExecTx, Error: %v", res)
+	payment := amt.Plus(coin.Coins{toll}).Negative()
+	assert.Equal(payment, diffIn)
+	assert.Equal(amt, diffOut)
+
 }
 
 func TestQuery(t *testing.T) {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -41,8 +41,8 @@ func newAppTest(t *testing.T) *appTest {
 }
 
 // make a tx sending 5mycoin from each acctIn to acctOut
-func (at *appTest) getTx(seq int, coins coin.Coins) basecoin.Tx {
-	in := []coin.TxInput{{Address: at.acctIn.Actor(), Coins: coins, Sequence: seq}}
+func (at *appTest) getTx(coins coin.Coins) basecoin.Tx {
+	in := []coin.TxInput{{Address: at.acctIn.Actor(), Coins: coins}}
 	out := []coin.TxOutput{{Address: at.acctOut.Actor(), Coins: coins}}
 	tx := coin.NewSendTx(in, out)
 	tx = base.NewChainTx(at.chainID, 0, tx)
@@ -193,22 +193,22 @@ func TestTx(t *testing.T) {
 	//Bad Balance
 	at.acctIn.Coins = coin.Coins{{"mycoin", 2}}
 	at.initAccount(at.acctIn)
-	res, _, _ := at.exec(t, at.getTx(1, coin.Coins{{"mycoin", 5}}), true)
+	res, _, _ := at.exec(t, at.getTx(coin.Coins{{"mycoin", 5}}), true)
 	assert.True(res.IsErr(), "ExecTx/Bad CheckTx: Expected error return from ExecTx, returned: %v", res)
-	res, diffIn, diffOut := at.exec(t, at.getTx(1, coin.Coins{{"mycoin", 5}}), false)
+	res, diffIn, diffOut := at.exec(t, at.getTx(coin.Coins{{"mycoin", 5}}), false)
 	assert.True(res.IsErr(), "ExecTx/Bad DeliverTx: Expected error return from ExecTx, returned: %v", res)
 	assert.True(diffIn.IsZero())
 	assert.True(diffOut.IsZero())
 
 	//Regular CheckTx
 	at.reset()
-	res, _, _ = at.exec(t, at.getTx(1, coin.Coins{{"mycoin", 5}}), true)
+	res, _, _ = at.exec(t, at.getTx(coin.Coins{{"mycoin", 5}}), true)
 	assert.True(res.IsOK(), "ExecTx/Good CheckTx: Expected OK return from ExecTx, Error: %v", res)
 
 	//Regular DeliverTx
 	at.reset()
 	amt := coin.Coins{{"mycoin", 3}}
-	res, diffIn, diffOut = at.exec(t, at.getTx(1, amt), false)
+	res, diffIn, diffOut = at.exec(t, at.getTx(amt), false)
 	assert.True(res.IsOK(), "ExecTx/Good DeliverTx: Expected OK return from ExecTx, Error: %v", res)
 	assert.Equal(amt.Negative(), diffIn)
 	assert.Equal(amt, diffOut)
@@ -218,7 +218,7 @@ func TestQuery(t *testing.T) {
 	assert := assert.New(t)
 	at := newAppTest(t)
 
-	res, _, _ := at.exec(t, at.getTx(1, coin.Coins{{"mycoin", 5}}), false)
+	res, _, _ := at.exec(t, at.getTx(coin.Coins{{"mycoin", 5}}), false)
 	assert.True(res.IsOK(), "Commit, DeliverTx: Expected OK return from DeliverTx, Error: %v", res)
 
 	resQueryPreCommit := at.app.Query(abci.RequestQuery{

--- a/app/genesis_test.go
+++ b/app/genesis_test.go
@@ -18,7 +18,7 @@ const genesisAcctFilepath = "./testdata/genesis2.json"
 
 func TestLoadGenesisDoNotFailIfAppOptionsAreMissing(t *testing.T) {
 	eyesCli := eyescli.NewLocalClient("", 0)
-	app := NewBasecoin(DefaultHandler(), eyesCli, log.TestingLogger())
+	app := NewBasecoin(DefaultHandler("mycoin"), eyesCli, log.TestingLogger())
 	err := app.LoadGenesis("./testdata/genesis3.json")
 	require.Nil(t, err, "%+v", err)
 }
@@ -27,7 +27,7 @@ func TestLoadGenesis(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	eyesCli := eyescli.NewLocalClient("", 0)
-	app := NewBasecoin(DefaultHandler(), eyesCli, log.TestingLogger())
+	app := NewBasecoin(DefaultHandler("mycoin"), eyesCli, log.TestingLogger())
 	err := app.LoadGenesis(genesisFilepath)
 	require.Nil(err, "%+v", err)
 
@@ -56,7 +56,7 @@ func TestLoadGenesisAccountAddress(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 
 	eyesCli := eyescli.NewLocalClient("", 0)
-	app := NewBasecoin(DefaultHandler(), eyesCli, log.TestingLogger())
+	app := NewBasecoin(DefaultHandler("mycoin"), eyesCli, log.TestingLogger())
 	err := app.LoadGenesis(genesisAcctFilepath)
 	require.Nil(err, "%+v", err)
 

--- a/cmd/basecli/commands/cmds.go
+++ b/cmd/basecli/commands/cmds.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tendermint/basecoin/modules/auth"
 	"github.com/tendermint/basecoin/modules/base"
 	"github.com/tendermint/basecoin/modules/coin"
+	"github.com/tendermint/basecoin/modules/fee"
 )
 
 //-------------------------
@@ -64,7 +65,10 @@ func doSendTx(cmd *cobra.Command, args []string) error {
 	}
 
 	// TODO: make this more flexible for middleware
-	// add the chain info
+	tx, err = WrapFeeTx(tx)
+	if err != nil {
+		return err
+	}
 	tx, err = WrapChainTx(tx)
 	if err != nil {
 		return err
@@ -83,6 +87,21 @@ func doSendTx(cmd *cobra.Command, args []string) error {
 	return txcmd.OutputTx(bres)
 }
 
+// WrapFeeTx checks for FlagFee and if present wraps the tx with a
+// FeeTx of the given amount, paid by the signer
+func WrapFeeTx(tx basecoin.Tx) (res basecoin.Tx, err error) {
+	//parse the fee and amounts into coin types
+	toll, err := coin.ParseCoin(viper.GetString(FlagFee))
+	if err != nil {
+		return res, err
+	}
+	// if no fee, do nothing, otherwise wrap it
+	if toll.IsZero() {
+		return tx, nil
+	}
+	return fee.NewFee(tx, toll, getSignerAddr()), nil
+}
+
 // WrapChainTx will wrap the tx with a ChainTx from the standard flags
 func WrapChainTx(tx basecoin.Tx) (res basecoin.Tx, err error) {
 	expires := viper.GetInt64(FlagExpires)
@@ -94,6 +113,15 @@ func WrapChainTx(tx basecoin.Tx) (res basecoin.Tx, err error) {
 	return res, nil
 }
 
+func getSignerAddr() (res basecoin.Actor) {
+	// this could be much cooler with multisig...
+	signer := txcmd.GetSigner()
+	if !signer.Empty() {
+		res = auth.SigPerm(signer.Address())
+	}
+	return res
+}
+
 func readSendTxFlags() (tx basecoin.Tx, err error) {
 	// parse to address
 	chain, to, err := parseChainAddress(viper.GetString(FlagTo))
@@ -103,29 +131,14 @@ func readSendTxFlags() (tx basecoin.Tx, err error) {
 	toAddr := auth.SigPerm(to)
 	toAddr.ChainID = chain
 
-	// //parse the fee and amounts into coin types
-	// tx.Fee, err = btypes.ParseCoin(viper.GetString(FlagFee))
-	// if err != nil {
-	// 	return err
-	// }
-	// // set the gas
-	// tx.Gas = viper.GetInt64(FlagGas)
-
 	amountCoins, err := coin.ParseCoins(viper.GetString(FlagAmount))
 	if err != nil {
 		return tx, err
 	}
 
-	// this could be much cooler with multisig...
-	var fromAddr basecoin.Actor
-	signer := txcmd.GetSigner()
-	if !signer.Empty() {
-		fromAddr = auth.SigPerm(signer.Address())
-	}
-
 	// craft the inputs and outputs
 	ins := []coin.TxInput{{
-		Address: fromAddr,
+		Address: getSignerAddr(),
 		Coins:   amountCoins,
 	}}
 	outs := []coin.TxOutput{{

--- a/cmd/basecli/commands/cmds.go
+++ b/cmd/basecli/commands/cmds.go
@@ -125,9 +125,8 @@ func readSendTxFlags() (tx basecoin.Tx, err error) {
 
 	// craft the inputs and outputs
 	ins := []coin.TxInput{{
-		Address:  fromAddr,
-		Coins:    amountCoins,
-		Sequence: viper.GetInt(FlagSequence),
+		Address: fromAddr,
+		Coins:   amountCoins,
 	}}
 	outs := []coin.TxOutput{{
 		Address: toAddr,

--- a/cmd/basecoin/main.go
+++ b/cmd/basecoin/main.go
@@ -11,7 +11,8 @@ import (
 func main() {
 	rt := commands.RootCmd
 
-	commands.Handler = app.DefaultHandler()
+	// require all fees in mycoin - change this in your app!
+	commands.Handler = app.DefaultHandler("mycoin")
 
 	rt.AddCommand(
 		commands.InitCmd,

--- a/docs/guide/counter/cmd/counter/main.go
+++ b/docs/guide/counter/cmd/counter/main.go
@@ -18,7 +18,7 @@ func main() {
 	}
 
 	// TODO: register the counter here
-	commands.Handler = counter.NewHandler()
+	commands.Handler = counter.NewHandler("mycoin")
 
 	RootCmd.AddCommand(
 		commands.InitCmd,

--- a/docs/guide/counter/plugins/counter/counter.go
+++ b/docs/guide/counter/plugins/counter/counter.go
@@ -23,7 +23,7 @@ import (
 // so it gets routed properly
 const (
 	NameCounter = "cntr"
-	ByteTx      = 0x21 //TODO What does this byte represent should use typebytes probably
+	ByteTx      = 0x2F //TODO What does this byte represent should use typebytes probably
 	TypeTx      = NameCounter + "/count"
 )
 

--- a/docs/guide/counter/plugins/counter/counter.go
+++ b/docs/guide/counter/plugins/counter/counter.go
@@ -145,7 +145,7 @@ func (h Handler) DeliverTx(ctx basecoin.Context, store state.KVStore, tx basecoi
 		if len(senders) == 0 {
 			return res, errors.ErrMissingSignature()
 		}
-		in := []coin.TxInput{{Address: senders[0], Coins: ctr.Fee, Sequence: ctr.Sequence}}
+		in := []coin.TxInput{{Address: senders[0], Coins: ctr.Fee}}
 		out := []coin.TxOutput{{Address: StoreActor(), Coins: ctr.Fee}}
 		send := coin.NewSendTx(in, out)
 		// if the deduction fails (too high), abort the command
@@ -170,7 +170,7 @@ func (h Handler) DeliverTx(ctx basecoin.Context, store state.KVStore, tx basecoi
 func checkTx(ctx basecoin.Context, tx basecoin.Tx) (ctr Tx, err error) {
 	ctr, ok := tx.Unwrap().(Tx)
 	if !ok {
-		return ctr, errors.ErrInvalidFormat(tx)
+		return ctr, errors.ErrInvalidFormat(TypeTx, tx)
 	}
 	err = ctr.ValidateBasic()
 	if err != nil {

--- a/docs/guide/counter/plugins/counter/counter.go
+++ b/docs/guide/counter/plugins/counter/counter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tendermint/basecoin/modules/auth"
 	"github.com/tendermint/basecoin/modules/base"
 	"github.com/tendermint/basecoin/modules/coin"
+	"github.com/tendermint/basecoin/modules/fee"
 	"github.com/tendermint/basecoin/stack"
 	"github.com/tendermint/basecoin/state"
 )
@@ -89,12 +90,12 @@ func ErrDecoding() error {
 //--------------------------------------------------------------------------------
 
 // NewHandler returns a new counter transaction processing handler
-func NewHandler() basecoin.Handler {
+func NewHandler(feeDenom string) basecoin.Handler {
 	// use the default stack
-	coin := coin.NewHandler()
+	ch := coin.NewHandler()
 	counter := Handler{}
 	dispatcher := stack.NewDispatcher(
-		stack.WrapHandler(coin),
+		stack.WrapHandler(ch),
 		counter,
 	)
 	return stack.New(
@@ -102,6 +103,7 @@ func NewHandler() basecoin.Handler {
 		stack.Recovery{},
 		auth.Signatures{},
 		base.Chain{},
+		fee.NewSimpleFeeMiddleware(coin.Coin{feeDenom, 0}, fee.Bank),
 	).Use(dispatcher)
 }
 

--- a/docs/guide/counter/plugins/counter/counter_test.go
+++ b/docs/guide/counter/plugins/counter/counter_test.go
@@ -27,7 +27,7 @@ func TestCounterPlugin(t *testing.T) {
 	logger := log.NewTMLogger(os.Stdout).With("module", "app")
 	// logger = log.NewTracingLogger(logger)
 	bcApp := app.NewBasecoin(
-		NewHandler(),
+		NewHandler("gold"),
 		eyesCli,
 		logger,
 	)

--- a/errors/common.go
+++ b/errors/common.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
+
 	abci "github.com/tendermint/abci/types"
 )
 
@@ -40,8 +41,7 @@ func unwrap(i interface{}) interface{} {
 
 func ErrUnknownTxType(tx interface{}) TMError {
 	msg := fmt.Sprintf("%T", unwrap(tx))
-	w := errors.Wrap(errUnknownTxType, msg)
-	return WithCode(w, abci.CodeType_UnknownRequest)
+	return WithMessage(msg, errUnknownTxType, abci.CodeType_UnknownRequest)
 }
 func IsUnknownTxTypeErr(err error) bool {
 	return IsSameError(errUnknownTxType, err)
@@ -49,16 +49,14 @@ func IsUnknownTxTypeErr(err error) bool {
 
 func ErrInvalidFormat(expected string, tx interface{}) TMError {
 	msg := fmt.Sprintf("%T not %s", unwrap(tx), expected)
-	w := errors.Wrap(errInvalidFormat, msg)
-	return WithCode(w, abci.CodeType_UnknownRequest)
+	return WithMessage(msg, errInvalidFormat, abci.CodeType_UnknownRequest)
 }
 func IsInvalidFormatErr(err error) bool {
 	return IsSameError(errInvalidFormat, err)
 }
 
 func ErrUnknownModule(mod string) TMError {
-	w := errors.Wrap(errUnknownModule, mod)
-	return WithCode(w, abci.CodeType_UnknownRequest)
+	return WithMessage(mod, errUnknownModule, abci.CodeType_UnknownRequest)
 }
 func IsUnknownModuleErr(err error) bool {
 	return IsSameError(errUnknownModule, err)

--- a/errors/common.go
+++ b/errors/common.go
@@ -47,8 +47,8 @@ func IsUnknownTxTypeErr(err error) bool {
 	return IsSameError(errUnknownTxType, err)
 }
 
-func ErrInvalidFormat(tx interface{}) TMError {
-	msg := fmt.Sprintf("%T", unwrap(tx))
+func ErrInvalidFormat(expected string, tx interface{}) TMError {
+	msg := fmt.Sprintf("%T not %s", unwrap(tx), expected)
 	w := errors.Wrap(errInvalidFormat, msg)
 	return WithCode(w, abci.CodeType_UnknownRequest)
 }

--- a/errors/main.go
+++ b/errors/main.go
@@ -104,6 +104,13 @@ func WithCode(err error, code abci.CodeType) TMError {
 	}
 }
 
+// WithMessage prepends some text to the error, then calls WithCode
+// It wraps the original error, so IsSameError will still match on err
+func WithMessage(prefix string, err error, code abci.CodeType) TMError {
+	e2 := errors.WithMessage(err, prefix)
+	return WithCode(e2, code)
+}
+
 // New adds a stacktrace if necessary and sets the code and msg,
 // overriding the state if err was already TMError
 func New(msg string, code abci.CodeType) TMError {

--- a/modules/coin/bench_test.go
+++ b/modules/coin/bench_test.go
@@ -15,8 +15,8 @@ func makeHandler() basecoin.Handler {
 	return NewHandler()
 }
 
-func makeSimpleTx(from, to basecoin.Actor, amount Coins, seq int) basecoin.Tx {
-	in := []TxInput{{Address: from, Coins: amount, Sequence: seq}}
+func makeSimpleTx(from, to basecoin.Actor, amount Coins) basecoin.Tx {
+	in := []TxInput{{Address: from, Coins: amount}}
 	out := []TxOutput{{Address: to, Coins: amount}}
 	return NewSendTx(in, out)
 }
@@ -35,7 +35,7 @@ func BenchmarkSimpleTransfer(b *testing.B) {
 	// now, loop...
 	for i := 1; i <= b.N; i++ {
 		ctx := stack.MockContext("foo", 100).WithPermissions(sender)
-		tx := makeSimpleTx(sender, receiver, Coins{{"mycoin", 2}}, i)
+		tx := makeSimpleTx(sender, receiver, Coins{{"mycoin", 2}})
 		_, err := h.DeliverTx(ctx, store, tx)
 		// never should error
 		if err != nil {

--- a/modules/coin/coin.go
+++ b/modules/coin/coin.go
@@ -16,8 +16,21 @@ type Coin struct {
 	Amount int64  `json:"amount"`
 }
 
+// String provides a human-readable representation of a coin
 func (coin Coin) String() string {
 	return fmt.Sprintf("%v%v", coin.Amount, coin.Denom)
+}
+
+// IsZero returns if this represents no money
+func (coin Coin) IsZero() bool {
+	return coin.Amount == 0
+}
+
+// IsGTE returns true if they are the same type and the receiver is
+// an equal or greater value
+func (coin Coin) IsGTE(other Coin) bool {
+	return (coin.Denom == other.Denom) &&
+		(coin.Amount >= other.Amount)
 }
 
 //regex codes for extracting coins from string

--- a/modules/coin/genesis.go
+++ b/modules/coin/genesis.go
@@ -15,16 +15,14 @@ import (
 type GenesisAccount struct {
 	Address data.Bytes `json:"address"`
 	// this from types.Account (don't know how to embed this properly)
-	PubKey   crypto.PubKey `json:"pub_key"` // May be nil, if not known.
-	Sequence int           `json:"sequence"`
-	Balance  Coins         `json:"coins"`
+	PubKey  crypto.PubKey `json:"pub_key"` // May be nil, if not known.
+	Balance Coins         `json:"coins"`
 }
 
 // ToAccount - GenesisAccount struct to a basecoin Account
 func (g GenesisAccount) ToAccount() Account {
 	return Account{
-		Sequence: g.Sequence,
-		Coins:    g.Balance,
+		Coins: g.Balance,
 	}
 }
 

--- a/modules/coin/handler.go
+++ b/modules/coin/handler.go
@@ -37,7 +37,7 @@ func (h Handler) CheckTx(ctx basecoin.Context, store state.KVStore, tx basecoin.
 
 	// now make sure there is money
 	for _, in := range send.Inputs {
-		_, err = CheckCoins(store, in.Address, in.Coins.Negative(), in.Sequence)
+		_, err = CheckCoins(store, in.Address, in.Coins.Negative())
 		if err != nil {
 			return res, err
 		}
@@ -56,7 +56,7 @@ func (h Handler) DeliverTx(ctx basecoin.Context, store state.KVStore, tx basecoi
 
 	// deduct from all input accounts
 	for _, in := range send.Inputs {
-		_, err = ChangeCoins(store, in.Address, in.Coins.Negative(), in.Sequence)
+		_, err = ChangeCoins(store, in.Address, in.Coins.Negative())
 		if err != nil {
 			return res, err
 		}
@@ -64,8 +64,7 @@ func (h Handler) DeliverTx(ctx basecoin.Context, store state.KVStore, tx basecoi
 
 	// add to all output accounts
 	for _, out := range send.Outputs {
-		// note: sequence number is ignored when adding coins, only checked for subtracting
-		_, err = ChangeCoins(store, out.Address, out.Coins, 0)
+		_, err = ChangeCoins(store, out.Address, out.Coins)
 		if err != nil {
 			return res, err
 		}
@@ -107,7 +106,7 @@ func checkTx(ctx basecoin.Context, tx basecoin.Tx) (send SendTx, err error) {
 	// check if the tx is proper type and valid
 	send, ok := tx.Unwrap().(SendTx)
 	if !ok {
-		return send, errors.ErrInvalidFormat(tx)
+		return send, errors.ErrInvalidFormat(TypeSend, tx)
 	}
 	err = send.ValidateBasic()
 	if err != nil {

--- a/modules/coin/handler_test.go
+++ b/modules/coin/handler_test.go
@@ -35,40 +35,40 @@ func TestHandlerValidation(t *testing.T) {
 		// auth works with different apps
 		{true,
 			NewSendTx(
-				[]TxInput{NewTxInput(addr1, someCoins, 2)},
+				[]TxInput{NewTxInput(addr1, someCoins)},
 				[]TxOutput{NewTxOutput(addr2, someCoins)}),
 			[]basecoin.Actor{addr1}},
 		{true,
 			NewSendTx(
-				[]TxInput{NewTxInput(addr2, someCoins, 2)},
+				[]TxInput{NewTxInput(addr2, someCoins)},
 				[]TxOutput{NewTxOutput(addr1, someCoins)}),
 			[]basecoin.Actor{addr1, addr2}},
 		// check multi-input with both sigs
 		{true,
 			NewSendTx(
-				[]TxInput{NewTxInput(addr1, someCoins, 2), NewTxInput(addr2, someCoins, 3)},
+				[]TxInput{NewTxInput(addr1, someCoins), NewTxInput(addr2, someCoins)},
 				[]TxOutput{NewTxOutput(addr1, doubleCoins)}),
 			[]basecoin.Actor{addr1, addr2}},
 		// wrong permissions fail
 		{false,
 			NewSendTx(
-				[]TxInput{NewTxInput(addr1, someCoins, 2)},
+				[]TxInput{NewTxInput(addr1, someCoins)},
 				[]TxOutput{NewTxOutput(addr2, someCoins)}),
 			[]basecoin.Actor{}},
 		{false,
 			NewSendTx(
-				[]TxInput{NewTxInput(addr1, someCoins, 2)},
+				[]TxInput{NewTxInput(addr1, someCoins)},
 				[]TxOutput{NewTxOutput(addr2, someCoins)}),
 			[]basecoin.Actor{addr2}},
 		{false,
 			NewSendTx(
-				[]TxInput{NewTxInput(addr1, someCoins, 2), NewTxInput(addr2, someCoins, 3)},
+				[]TxInput{NewTxInput(addr1, someCoins), NewTxInput(addr2, someCoins)},
 				[]TxOutput{NewTxOutput(addr1, doubleCoins)}),
 			[]basecoin.Actor{addr1}},
 		// invalid input fails
 		{false,
 			NewSendTx(
-				[]TxInput{NewTxInput(addr1, minusCoins, 2)},
+				[]TxInput{NewTxInput(addr1, minusCoins)},
 				[]TxOutput{NewTxOutput(addr2, minusCoins)}),
 			[]basecoin.Actor{addr2}},
 	}
@@ -113,7 +113,7 @@ func TestDeliverTx(t *testing.T) {
 		{
 			[]money{{addr1, moreCoins}},
 			NewSendTx(
-				[]TxInput{NewTxInput(addr1, someCoins, 1)},
+				[]TxInput{NewTxInput(addr1, someCoins)},
 				[]TxOutput{NewTxOutput(addr2, someCoins)}),
 			[]basecoin.Actor{addr1},
 			[]money{{addr1, diffCoins}, {addr2, someCoins}},
@@ -122,7 +122,7 @@ func TestDeliverTx(t *testing.T) {
 		{
 			[]money{{addr1, mixedCoins}, {addr2, moreCoins}},
 			NewSendTx(
-				[]TxInput{NewTxInput(addr1, otherCoins, 1), NewTxInput(addr2, someCoins, 1)},
+				[]TxInput{NewTxInput(addr1, otherCoins), NewTxInput(addr2, someCoins)},
 				[]TxOutput{NewTxOutput(addr3, mixedCoins)}),
 			[]basecoin.Actor{addr1, addr2},
 			[]money{{addr1, someCoins}, {addr2, diffCoins}, {addr3, mixedCoins}},
@@ -131,7 +131,7 @@ func TestDeliverTx(t *testing.T) {
 		{
 			[]money{{addr1, moreCoins.Plus(otherCoins)}},
 			NewSendTx(
-				[]TxInput{NewTxInput(addr1, otherCoins, 1), NewTxInput(addr1, someCoins, 2)},
+				[]TxInput{NewTxInput(addr1, otherCoins), NewTxInput(addr1, someCoins)},
 				[]TxOutput{NewTxOutput(addr2, mixedCoins)}),
 			[]basecoin.Actor{addr1},
 			[]money{{addr1, diffCoins}, {addr2, mixedCoins}},

--- a/modules/coin/helper.go
+++ b/modules/coin/helper.go
@@ -39,9 +39,8 @@ func (a *AccountWithKey) Actor() basecoin.Actor {
 // This is intended for use in test cases
 func (a *AccountWithKey) MakeOption() string {
 	info := GenesisAccount{
-		Address:  a.Address(),
-		Sequence: a.Sequence,
-		Balance:  a.Coins,
+		Address: a.Address(),
+		Balance: a.Coins,
 	}
 	js, err := data.ToJSON(info)
 	if err != nil {

--- a/modules/coin/store.go
+++ b/modules/coin/store.go
@@ -63,8 +63,7 @@ func updateCoins(store state.KVStore, addr basecoin.Actor, coins Coins) (acct Ac
 
 // Account - coin account structure
 type Account struct {
-	Coins    Coins `json:"coins"`
-	Sequence int   `json:"sequence"`
+	Coins Coins `json:"coins"`
 }
 
 func loadAccount(store state.KVStore, key []byte) (acct Account, err error) {

--- a/modules/coin/store.go
+++ b/modules/coin/store.go
@@ -22,14 +22,14 @@ func GetAccount(store state.KVStore, addr basecoin.Actor) (Account, error) {
 }
 
 // CheckCoins makes sure there are funds, but doesn't change anything
-func CheckCoins(store state.KVStore, addr basecoin.Actor, coins Coins, seq int) (Coins, error) {
-	acct, err := updateCoins(store, addr, coins, seq)
+func CheckCoins(store state.KVStore, addr basecoin.Actor, coins Coins) (Coins, error) {
+	acct, err := updateCoins(store, addr, coins)
 	return acct.Coins, err
 }
 
 // ChangeCoins changes the money, returns error if it would be negative
-func ChangeCoins(store state.KVStore, addr basecoin.Actor, coins Coins, seq int) (Coins, error) {
-	acct, err := updateCoins(store, addr, coins, seq)
+func ChangeCoins(store state.KVStore, addr basecoin.Actor, coins Coins) (Coins, error) {
+	acct, err := updateCoins(store, addr, coins)
 	if err != nil {
 		return acct.Coins, err
 	}
@@ -41,7 +41,7 @@ func ChangeCoins(store state.KVStore, addr basecoin.Actor, coins Coins, seq int)
 // updateCoins will load the account, make all checks, and return the updated account.
 //
 // it doesn't save anything, that is up to you to decide (Check/Change Coins)
-func updateCoins(store state.KVStore, addr basecoin.Actor, coins Coins, seq int) (acct Account, err error) {
+func updateCoins(store state.KVStore, addr basecoin.Actor, coins Coins) (acct Account, err error) {
 	acct, err = loadAccount(store, addr.Bytes())
 	// we can increase an empty account...
 	if IsNoAccountErr(err) && coins.IsPositive() {
@@ -49,14 +49,6 @@ func updateCoins(store state.KVStore, addr basecoin.Actor, coins Coins, seq int)
 	}
 	if err != nil {
 		return acct, err
-	}
-
-	// check sequence if we are deducting... ugh, need a cleaner replay protection
-	if !coins.IsPositive() {
-		if seq != acct.Sequence+1 {
-			return acct, ErrInvalidSequence()
-		}
-		acct.Sequence++
 	}
 
 	// check amount

--- a/modules/coin/tx_test.go
+++ b/modules/coin/tx_test.go
@@ -46,26 +46,14 @@ var coins = []struct {
 func TestTxValidateInput(t *testing.T) {
 	assert := assert.New(t)
 
-	seqs := []struct {
-		seq   int
-		valid bool
-	}{
-		{-3, false},
-		{0, false},
-		{1, true},
-		{6571265735, true},
-	}
-
 	for i, act := range actors {
 		for j, coin := range coins {
-			for k, seq := range seqs {
-				input := NewTxInput(act.actor, coin.coins, seq.seq)
-				err := input.ValidateBasic()
-				if act.valid && coin.valid && seq.valid {
-					assert.Nil(err, "%d,%d,%d: %+v", i, j, k, err)
-				} else {
-					assert.NotNil(err, "%d,%d,%d", i, j, k)
-				}
+			input := NewTxInput(act.actor, coin.coins)
+			err := input.ValidateBasic()
+			if act.valid && coin.valid {
+				assert.Nil(err, "%d,%d: %+v", i, j, err)
+			} else {
+				assert.NotNil(err, "%d,%d", i, j)
 			}
 		}
 	}
@@ -111,15 +99,15 @@ func TestTxValidateTx(t *testing.T) {
 	}{
 		// 0-2. valid cases
 		{true, NewSendTx(
-			[]TxInput{NewTxInput(addr1, someCoins, 2)},
+			[]TxInput{NewTxInput(addr1, someCoins)},
 			[]TxOutput{NewTxOutput(addr2, someCoins)},
 		)},
 		{true, NewSendTx(
-			[]TxInput{NewTxInput(addr1, someCoins, 2), NewTxInput(addr2, otherCoins, 5)},
+			[]TxInput{NewTxInput(addr1, someCoins), NewTxInput(addr2, otherCoins)},
 			[]TxOutput{NewTxOutput(addr3, bothCoins)},
 		)},
 		{true, NewSendTx(
-			[]TxInput{NewTxInput(addr1, bothCoins, 42)},
+			[]TxInput{NewTxInput(addr1, bothCoins)},
 			[]TxOutput{NewTxOutput(addr2, someCoins), NewTxOutput(addr3, otherCoins)},
 		)},
 
@@ -129,39 +117,35 @@ func TestTxValidateTx(t *testing.T) {
 			[]TxOutput{NewTxOutput(addr2, someCoins)},
 		)},
 		{false, NewSendTx(
-			[]TxInput{NewTxInput(addr1, someCoins, 2)},
+			[]TxInput{NewTxInput(addr1, someCoins)},
 			nil,
 		)},
 
-		// 5-8. invalid inputs
+		// 5-7. invalid inputs
 		{false, NewSendTx(
-			[]TxInput{NewTxInput(noAddr, someCoins, 2)},
+			[]TxInput{NewTxInput(noAddr, someCoins)},
 			[]TxOutput{NewTxOutput(addr2, someCoins)},
 		)},
 		{false, NewSendTx(
-			[]TxInput{NewTxInput(addr1, someCoins, -1)},
-			[]TxOutput{NewTxOutput(addr2, someCoins)},
-		)},
-		{false, NewSendTx(
-			[]TxInput{NewTxInput(addr1, noCoins, 2)},
+			[]TxInput{NewTxInput(addr1, noCoins)},
 			[]TxOutput{NewTxOutput(addr2, noCoins)},
 		)},
 		{false, NewSendTx(
-			[]TxInput{NewTxInput(addr1, minusCoins, 2)},
+			[]TxInput{NewTxInput(addr1, minusCoins)},
 			[]TxOutput{NewTxOutput(addr2, minusCoins)},
 		)},
 
-		// 9-11. totals don't match
+		// 8-10. totals don't match
 		{false, NewSendTx(
-			[]TxInput{NewTxInput(addr1, someCoins, 7)},
+			[]TxInput{NewTxInput(addr1, someCoins)},
 			[]TxOutput{NewTxOutput(addr2, moreCoins)},
 		)},
 		{false, NewSendTx(
-			[]TxInput{NewTxInput(addr1, someCoins, 2), NewTxInput(addr2, minusCoins, 5)},
+			[]TxInput{NewTxInput(addr1, someCoins), NewTxInput(addr2, minusCoins)},
 			[]TxOutput{NewTxOutput(addr3, someCoins)},
 		)},
 		{false, NewSendTx(
-			[]TxInput{NewTxInput(addr1, someCoins, 2), NewTxInput(addr2, moreCoins, 5)},
+			[]TxInput{NewTxInput(addr1, someCoins), NewTxInput(addr2, moreCoins)},
 			[]TxOutput{NewTxOutput(addr3, bothCoins)},
 		)},
 	}
@@ -185,7 +169,7 @@ func TestTxSerializeTx(t *testing.T) {
 	someCoins := Coins{{"atom", 123}}
 
 	send := NewSendTx(
-		[]TxInput{NewTxInput(addr1, someCoins, 2)},
+		[]TxInput{NewTxInput(addr1, someCoins)},
 		[]TxOutput{NewTxOutput(addr2, someCoins)},
 	)
 

--- a/modules/fee/error_test.go
+++ b/modules/fee/error_test.go
@@ -1,0 +1,19 @@
+package fee
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrors(t *testing.T) {
+	assert := assert.New(t)
+
+	e := ErrInsufficientFees()
+	assert.True(IsInsufficientFeesErr(e))
+	assert.False(IsWrongFeeDenomErr(e))
+
+	e2 := ErrWrongFeeDenom("atom")
+	assert.False(IsInsufficientFeesErr(e2))
+	assert.True(IsWrongFeeDenomErr(e2))
+}

--- a/modules/fee/errors.go
+++ b/modules/fee/errors.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 
 	abci "github.com/tendermint/abci/types"
+
 	"github.com/tendermint/basecoin/errors"
 )
 
 var (
 	errInsufficientFees = fmt.Errorf("Insufficient Fees")
+	errWrongFeeDenom    = fmt.Errorf("Required fee denomination")
 )
 
 func ErrInsufficientFees() errors.TMError {
@@ -17,4 +19,11 @@ func ErrInsufficientFees() errors.TMError {
 }
 func IsInsufficientFeesErr(err error) bool {
 	return errors.IsSameError(errInsufficientFees, err)
+}
+
+func ErrWrongFeeDenom(denom string) errors.TMError {
+	return errors.WithMessage(denom, errWrongFeeDenom, abci.CodeType_BaseInvalidInput)
+}
+func IsWrongFeeDenomErr(err error) bool {
+	return errors.IsSameError(errWrongFeeDenom, err)
 }

--- a/modules/fee/errors.go
+++ b/modules/fee/errors.go
@@ -2,14 +2,14 @@
 package fee
 
 import (
-	rawerr "errors"
+	"fmt"
 
 	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/basecoin/errors"
 )
 
 var (
-	errInsufficientFees = rawerr.New("Insufficient Fees")
+	errInsufficientFees = fmt.Errorf("Insufficient Fees")
 )
 
 func ErrInsufficientFees() errors.TMError {

--- a/modules/fee/handler.go
+++ b/modules/fee/handler.go
@@ -24,9 +24,10 @@ var _ stack.Middleware = SimpleFeeMiddleware{}
 // NewSimpleFeeMiddleware returns a fee handler with a fixed minimum fee.
 //
 // If minFee is 0, then the FeeTx is optional
-func NewSimpleFeeMiddleware(minFee coin.Coin) SimpleFeeMiddleware {
+func NewSimpleFeeMiddleware(minFee coin.Coin, collector basecoin.Actor) SimpleFeeMiddleware {
 	return SimpleFeeMiddleware{
-		MinFee: minFee,
+		MinFee:    minFee,
+		Collector: collector,
 	}
 }
 

--- a/modules/fee/handler.go
+++ b/modules/fee/handler.go
@@ -11,76 +11,62 @@ import (
 // NameFee - namespace for the fee module
 const NameFee = "fee"
 
-// AccountChecker - interface used by SimpleFeeHandler
-type AccountChecker interface {
-	// Get amount checks the current amount
-	GetAmount(store state.KVStore, addr basecoin.Actor) (coin.Coins, error)
-
-	// ChangeAmount modifies the balance by the given amount and returns the new balance
-	// always returns an error if leading to negative balance
-	ChangeAmount(store state.KVStore, addr basecoin.Actor, coins coin.Coins) (coin.Coins, error)
-}
-
-// SimpleFeeHandler - checker object for fee checking
-type SimpleFeeHandler struct {
-	AccountChecker
-	MinFee coin.Coins
+// SimpleFeeMiddleware - middleware for fee checking, constant amount
+// It used modules.coin to move the money
+type SimpleFeeMiddleware struct {
+	MinFee    coin.Coin //
+	Collector basecoin.Actor
 	stack.PassOption
 }
 
+var _ stack.Middleware = SimpleFeeMiddleware{}
+
+// NewSimpleFeeMiddleware returns a fee handler with a fixed minimum fee.
+//
+// If minFee is 0, then the FeeTx is optional
+func NewSimpleFeeMiddleware(minFee coin.Coin) SimpleFeeMiddleware {
+	return SimpleFeeMiddleware{
+		MinFee: minFee,
+	}
+}
+
 // Name - return the namespace for the fee module
-func (SimpleFeeHandler) Name() string {
+func (SimpleFeeMiddleware) Name() string {
 	return NameFee
 }
 
-var _ stack.Middleware = SimpleFeeHandler{}
-
-// Yes, I know refactor a bit... really too late already
-
 // CheckTx - check the transaction
-func (h SimpleFeeHandler) CheckTx(ctx basecoin.Context, store state.KVStore, tx basecoin.Tx, next basecoin.Checker) (res basecoin.Result, err error) {
-	feeTx, ok := tx.Unwrap().(*Fee)
-	if !ok {
-		return res, errors.ErrInvalidFormat(tx)
-	}
-
-	fees := coin.Coins{feeTx.Fee}
-	if !fees.IsGTE(h.MinFee) {
-		return res, ErrInsufficientFees()
-	}
-
-	if !ctx.HasPermission(feeTx.Payer) {
-		return res, errors.ErrUnauthorized()
-	}
-
-	_, err = h.ChangeAmount(store, feeTx.Payer, fees.Negative())
-	if err != nil {
-		return res, err
-	}
-
-	return basecoin.Result{Log: "Valid tx"}, nil
+func (h SimpleFeeMiddleware) CheckTx(ctx basecoin.Context, store state.KVStore, tx basecoin.Tx, next basecoin.Checker) (res basecoin.Result, err error) {
+	return h.doTx(ctx, store, tx, next.CheckTx)
 }
 
 // DeliverTx - send the fee handler transaction
-func (h SimpleFeeHandler) DeliverTx(ctx basecoin.Context, store state.KVStore, tx basecoin.Tx, next basecoin.Deliver) (res basecoin.Result, err error) {
-	feeTx, ok := tx.Unwrap().(*Fee)
+func (h SimpleFeeMiddleware) DeliverTx(ctx basecoin.Context, store state.KVStore, tx basecoin.Tx, next basecoin.Deliver) (res basecoin.Result, err error) {
+	return h.doTx(ctx, store, tx, next.DeliverTx)
+}
+
+func (h SimpleFeeMiddleware) doTx(ctx basecoin.Context, store state.KVStore, tx basecoin.Tx, next basecoin.CheckerFunc) (res basecoin.Result, err error) {
+	feeTx, ok := tx.Unwrap().(Fee)
 	if !ok {
-		return res, errors.ErrInvalidFormat(tx)
+		// the fee wrapper is not required if there is no minimum
+		if h.MinFee.IsZero() {
+			return next(ctx, store, tx)
+		}
+		return res, errors.ErrInvalidFormat(TypeFees, tx)
 	}
 
-	fees := coin.Coins{feeTx.Fee}
-	if !fees.IsGTE(h.MinFee) {
+	// see if it is big enough...
+	fee := feeTx.Fee
+	if !fee.IsGTE(h.MinFee) {
 		return res, ErrInsufficientFees()
 	}
 
-	if !ctx.HasPermission(feeTx.Payer) {
-		return res, errors.ErrUnauthorized()
-	}
-
-	_, err = h.ChangeAmount(store, feeTx.Payer, fees.Negative())
+	// now, try to make a IPC call to coins...
+	send := coin.NewSendOneTx(feeTx.Payer, h.Collector, coin.Coins{fee})
+	_, err = next(ctx, store, send)
 	if err != nil {
 		return res, err
 	}
 
-	return next.DeliverTx(ctx, store, feeTx.Next())
+	return next(ctx, store, feeTx.Tx)
 }

--- a/modules/fee/handler.go
+++ b/modules/fee/handler.go
@@ -11,6 +11,10 @@ import (
 // NameFee - namespace for the fee module
 const NameFee = "fee"
 
+// Bank is a default location for the fees, but pass anything into
+// the middleware constructor
+var Bank = basecoin.Actor{App: NameFee, Address: []byte("bank")}
+
 // SimpleFeeMiddleware - middleware for fee checking, constant amount
 // It used modules.coin to move the money
 type SimpleFeeMiddleware struct {

--- a/modules/fee/handler_test.go
+++ b/modules/fee/handler_test.go
@@ -6,12 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tendermint/tmlibs/log"
+
 	"github.com/tendermint/basecoin"
 	"github.com/tendermint/basecoin/modules/coin"
 	"github.com/tendermint/basecoin/modules/fee"
 	"github.com/tendermint/basecoin/stack"
 	"github.com/tendermint/basecoin/state"
-	"github.com/tendermint/tmlibs/log"
 )
 
 func TestFeeChecks(t *testing.T) {

--- a/modules/fee/handler_test.go
+++ b/modules/fee/handler_test.go
@@ -29,7 +29,7 @@ func TestFeeChecks(t *testing.T) {
 	pure := atoms(46657)
 
 	// these are some accounts
-	collector := basecoin.Actor{App: fee.NameFee, Address: []byte("bank")}
+	collector := basecoin.Actor{App: fee.NameFee, Address: []byte("mine")}
 	key1 := coin.NewAccountWithKey(mixed)
 	key2 := coin.NewAccountWithKey(pure)
 	act1, act2 := key1.Actor(), key2.Actor()

--- a/modules/fee/handler_test.go
+++ b/modules/fee/handler_test.go
@@ -1,0 +1,134 @@
+package fee_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/basecoin"
+	"github.com/tendermint/basecoin/modules/coin"
+	"github.com/tendermint/basecoin/modules/fee"
+	"github.com/tendermint/basecoin/stack"
+	"github.com/tendermint/basecoin/state"
+	"github.com/tendermint/tmlibs/log"
+)
+
+func TestFeeChecks(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	atom := func(i int64) coin.Coin { return coin.Coin{"atom", i} }
+	eth := func(i int64) coin.Coin { return coin.Coin{"eth", i} }
+	atoms := func(i int64) coin.Coins { return coin.Coins{{"atom", i}} }
+	wallet := func(i, j int64) coin.Coins { return coin.Coins{atom(i), eth(j)} }
+
+	// some coin amounts...
+	zero := coin.Coin{}
+	mixed := wallet(1200, 55)
+	pure := atoms(46657)
+
+	// these are some accounts
+	collector := basecoin.Actor{App: fee.NameFee, Address: []byte("bank")}
+	key1 := coin.NewAccountWithKey(mixed)
+	key2 := coin.NewAccountWithKey(pure)
+	act1, act2 := key1.Actor(), key2.Actor()
+
+	// set up the apps....
+	disp := stack.NewDispatcher(
+		// OKHandler will just return success to a RawTx
+		stack.WrapHandler(stack.OKHandler{}),
+		// coin is needed to handle the IPC call from Fee middleware
+		stack.WrapHandler(coin.NewHandler()),
+	)
+	// app1 requires no fees
+	app1 := stack.New(fee.NewSimpleFeeMiddleware(atom(0), collector)).Use(disp)
+	// app2 requires 2 atom
+	app2 := stack.New(fee.NewSimpleFeeMiddleware(atom(2), collector)).Use(disp)
+
+	// set up the store and init the accounts
+	store := state.NewMemKVStore()
+	l := log.NewNopLogger()
+	_, err := app1.SetOption(l, store, "coin", "account", key1.MakeOption())
+	require.Nil(err, "%+v", err)
+	_, err = app2.SetOption(l, store, "coin", "account", key2.MakeOption())
+	require.Nil(err, "%+v", err)
+
+	cases := []struct {
+		valid bool
+		// this is the middleware stack to test
+		app basecoin.Handler
+		// they sign the tx
+		signer basecoin.Actor
+		// wrap with the given fee if hasFee is true
+		hasFee bool
+		payer  basecoin.Actor
+		fee    coin.Coin
+		// expected balance after the tx
+		left      coin.Coins
+		collected coin.Coins
+	}{
+		// make sure it works with no fee (control group)
+		{true, app1, act1, false, act1, zero, mixed, nil},
+		{true, app1, act2, false, act2, zero, pure, nil},
+
+		// no fee or too low is rejected
+		{false, app2, act1, false, act1, zero, mixed, nil},
+		{false, app2, act2, false, act2, zero, pure, nil},
+		{false, app2, act1, true, act1, zero, mixed, nil},
+		{false, app2, act2, true, act2, atom(1), pure, nil},
+
+		// proper fees are transfered in both cases
+		{true, app1, act1, true, act1, atom(1), wallet(1199, 55), atoms(1)},
+		{true, app2, act2, true, act2, atom(57), atoms(46600), atoms(58)},
+
+		// // fee must be the proper type...
+		{false, app1, act1, true, act1, eth(5), wallet(1199, 55), atoms(58)},
+
+		// signature must match
+		{false, app2, act1, true, act2, atom(5), atoms(46600), atoms(58)},
+
+		// send only works within limits
+		{true, app2, act1, true, act1, atom(1100), wallet(99, 55), atoms(1158)},
+		{false, app2, act1, true, act1, atom(500), wallet(99, 55), atoms(1158)},
+	}
+
+	for i, tc := range cases {
+		// build the tx
+		tx := stack.NewRawTx([]byte{7, 8, 9})
+		if tc.hasFee {
+			tx = fee.NewFee(tx, tc.fee, tc.payer)
+		}
+
+		// set up the permissions
+		ctx := stack.MockContext("x", 1).WithPermissions(tc.signer)
+
+		// call checktx...
+		_, err := tc.app.CheckTx(ctx, store, tx)
+		if tc.valid {
+			assert.Nil(err, "%d: %+v", i, err)
+		} else {
+			assert.NotNil(err, "%d", i)
+		}
+
+		// call delivertx...
+		_, err = tc.app.DeliverTx(ctx, store, tx)
+		if tc.valid {
+			assert.Nil(err, "%d: %+v", i, err)
+		} else {
+			assert.NotNil(err, "%d", i)
+		}
+
+		// check the account balance afterwards....
+		cspace := stack.PrefixedStore(coin.NameCoin, store)
+		acct, err := coin.GetAccount(cspace, tc.payer)
+		require.Nil(err, "%d: %+v", i, err)
+		assert.Equal(tc.left, acct.Coins, "%d", i)
+
+		// check the collected balance afterwards....
+		acct, err = coin.GetAccount(cspace, collector)
+		require.Nil(err, "%d: %+v", i, err)
+		assert.Equal(tc.collected, acct.Coins, "%d", i)
+	}
+
+}

--- a/modules/fee/tx.go
+++ b/modules/fee/tx.go
@@ -7,38 +7,38 @@ import (
 
 // nolint
 const (
-	ByteFees = 0x20
-	TypeFees = "fee"
+	ByteFees = 0x21
+	TypeFees = NameFee + "/tx"
 )
 
 func init() {
 	basecoin.TxMapper.
-		RegisterImplementation(&Fee{}, TypeFees, ByteFees)
+		RegisterImplementation(Fee{}, TypeFees, ByteFees)
 }
 
 /**** Fee ****/
 
-var _ basecoin.TxLayer = &Fee{}
-
 // Fee attaches a fee payment to the embedded tx
 type Fee struct {
-	Tx    basecoin.Tx    `json:"tx"`
+	// Gas coin.Coin `json:"gas"`  // ?????
 	Fee   coin.Coin      `json:"fee"`
 	Payer basecoin.Actor `json:"payer"` // the address who pays the fee
-	// Gas coin.Coin `json:"gas"`  // ?????
+	Tx    basecoin.Tx    `json:"tx"`
+}
+
+// NewFee wraps a tx with a promised fee from this actor
+func NewFee(tx basecoin.Tx, fee coin.Coin, payer basecoin.Actor) basecoin.Tx {
+	return Fee{Tx: tx, Fee: fee, Payer: payer}.Wrap()
 }
 
 // nolint - TxInner Functions
-func NewFee(tx basecoin.Tx, fee coin.Coin, payer basecoin.Actor) basecoin.Tx {
-	return (&Fee{Tx: tx, Fee: fee, Payer: payer}).Wrap()
-}
-func (f *Fee) ValidateBasic() error {
+func (f Fee) ValidateBasic() error {
 	// TODO: more checks
 	return f.Tx.ValidateBasic()
 }
-func (f *Fee) Wrap() basecoin.Tx {
+func (f Fee) Wrap() basecoin.Tx {
 	return basecoin.Tx{f}
 }
-func (f *Fee) Next() basecoin.Tx {
+func (f Fee) Next() basecoin.Tx {
 	return f.Tx
 }

--- a/modules/roles/handler.go
+++ b/modules/roles/handler.go
@@ -56,7 +56,7 @@ func checkTx(ctx basecoin.Context, tx basecoin.Tx) (create CreateRoleTx, err err
 	// check if the tx is proper type and valid
 	create, ok := tx.Unwrap().(CreateRoleTx)
 	if !ok {
-		return create, errors.ErrInvalidFormat(tx)
+		return create, errors.ErrInvalidFormat(TypeCreateRoleTx, tx)
 	}
 	err = create.ValidateBasic()
 	return create, err

--- a/stack/helpers.go
+++ b/stack/helpers.go
@@ -21,7 +21,7 @@ const (
 	ByteRawTx   = 0xF0
 	ByteCheckTx = 0xF1
 
-	TypeRawTx   = "raw"
+	TypeRawTx   = NameOK + "/raw" // this will just say a-ok to RawTx
 	TypeCheckTx = NameCheck + "/tx"
 
 	rawMaxSize = 2000 * 1000

--- a/tests/cli/basictx.sh
+++ b/tests/cli/basictx.sh
@@ -63,7 +63,7 @@ test02SendTxWithFee() {
     checkAccount $RECV "1082"
 
     # Make sure tx is indexed
-    # checkSendFeeTx $HASH $TX_HEIGHT $SENDER "90" "10"
+    checkSendFeeTx $HASH $TX_HEIGHT $SENDER "90" "10"
 }
 
 

--- a/tests/cli/basictx.sh
+++ b/tests/cli/basictx.sh
@@ -23,7 +23,7 @@ test00GetAccount() {
 
     assertFalse "requires arg" "${CLIENT_EXE} query account"
 
-    checkAccount $SENDER "0" "9007199254740992"
+    checkAccount $SENDER "9007199254740992"
 
     ACCT2=$(${CLIENT_EXE} query account $RECV 2>/dev/null)
     assertFalse "has no genesis account" $?
@@ -40,10 +40,10 @@ test01SendTx() {
     HASH=$(echo $TX | jq .hash | tr -d \")
     TX_HEIGHT=$(echo $TX | jq .height)
 
-    checkAccount $SENDER "1" "9007199254740000"
+    checkAccount $SENDER "9007199254740000"
     # make sure 0x prefix also works
-    checkAccount "0x$SENDER" "1" "9007199254740000"
-    checkAccount $RECV "0" "992"
+    checkAccount "0x$SENDER" "9007199254740000"
+    checkAccount $RECV "992"
 
     # Make sure tx is indexed
     checkSendTx $HASH $TX_HEIGHT $SENDER "992"

--- a/tests/cli/basictx.sh
+++ b/tests/cli/basictx.sh
@@ -49,6 +49,24 @@ test01SendTx() {
     checkSendTx $HASH $TX_HEIGHT $SENDER "992"
 }
 
+test02SendTxWithFee() {
+    SENDER=$(getAddr $RICH)
+    RECV=$(getAddr $POOR)
+
+    TX=$(echo qwertyuiop | ${CLIENT_EXE} tx send --amount=90mycoin --fee=10mycoin --sequence=2 --to=$RECV --name=$RICH)
+    txSucceeded $? "$TX" "$RECV"
+    HASH=$(echo $TX | jq .hash | tr -d \")
+    TX_HEIGHT=$(echo $TX | jq .height)
+
+    # deduct 100 from sender, add 90 to receiver... fees "vanish"
+    checkAccount $SENDER "9007199254739900"
+    checkAccount $RECV "1082"
+
+    # Make sure tx is indexed
+    # checkSendFeeTx $HASH $TX_HEIGHT $SENDER "90" "10"
+}
+
+
 # Load common then run these tests with shunit2!
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" #get this files directory
 . $DIR/common.sh

--- a/tests/cli/common.sh
+++ b/tests/cli/common.sh
@@ -124,6 +124,7 @@ getAddr() {
     echo $RAW | cut -d' ' -f2
 }
 
+# XXX Ex Usage: checkAccount $ADDR $AMOUNT
 # Desc: Assumes just one coin, checks the balance of first coin in any case
 checkAccount() {
     # make sure sender goes down
@@ -133,8 +134,7 @@ checkAccount() {
     fi
 
     if [ -n "$DEBUG" ]; then echo $ACCT; echo; fi
-    assertEquals "proper sequence" "$2" $(echo $ACCT | jq .data.sequence)
-    assertEquals "proper money" "$3" $(echo $ACCT | jq .data.coins[0].amount)
+    assertEquals "proper money" "$2" $(echo $ACCT | jq .data.coins[0].amount)
     return $?
 }
 

--- a/tests/cli/counter.sh
+++ b/tests/cli/counter.sh
@@ -23,7 +23,7 @@ test00GetAccount() {
 
     assertFalse "requires arg" "${CLIENT_EXE} query account"
 
-    checkAccount $SENDER "0" "9007199254740992"
+    checkAccount $SENDER "9007199254740992"
 
     ACCT2=$(${CLIENT_EXE} query account $RECV 2>/dev/null)
     assertFalse "has no genesis account" $?
@@ -40,8 +40,8 @@ test01SendTx() {
     HASH=$(echo $TX | jq .hash | tr -d \")
     TX_HEIGHT=$(echo $TX | jq .height)
 
-    checkAccount $SENDER "1" "9007199254740000"
-    checkAccount $RECV "0" "992"
+    checkAccount $SENDER "9007199254740000"
+    checkAccount $RECV "992"
 
     # make sure tx is indexed
     checkSendTx $HASH $TX_HEIGHT $SENDER "992"
@@ -76,7 +76,7 @@ test03AddCount() {
     checkCounter "1" "10"
 
     # make sure the account was debited
-    checkAccount $SENDER "2" "9007199254739990"
+    checkAccount $SENDER "9007199254739990"
 
     # make sure tx is indexed
     TX=$(${CLIENT_EXE} query tx $HASH --trace)

--- a/tests/cli/counter.sh
+++ b/tests/cli/counter.sh
@@ -89,6 +89,16 @@ test03AddCount() {
       assertEquals "type=cntr/count" '"cntr/count"' $(echo $CNTX | jq .type)
       assertEquals "proper fee" "10" $(echo $CNTX | jq .data.fee[0].amount)
     fi
+
+    # test again with fees...
+    TX=$(echo qwertyuiop | ${CLIENT_EXE} tx counter --countfee=7mycoin --fee=4mycoin --sequence=3 --name=${RICH} --valid)
+    txSucceeded $? "$TX" "counter"
+
+    # make sure the counter was updated, added 7
+    checkCounter "2" "17"
+
+    # make sure the account was debited 11
+    checkAccount $SENDER "9007199254739979"
 }
 
 # Load common then run these tests with shunit2!

--- a/tests/cli/restart.sh
+++ b/tests/cli/restart.sh
@@ -26,8 +26,8 @@ test00PreRestart() {
     HASH=$(echo $TX | jq .hash | tr -d \")
     TX_HEIGHT=$(echo $TX | jq .height)
 
-    checkAccount $SENDER "1" "9007199254740000"
-    checkAccount $RECV "0" "992"
+    checkAccount $SENDER "9007199254740000"
+    checkAccount $RECV "992"
 
     # make sure tx is indexed
     checkSendTx $HASH $TX_HEIGHT $SENDER "992"
@@ -63,8 +63,8 @@ test01OnRestart() {
 
     # make sure queries still work properly, with all 3 tx now executed
     echo "Checking state after restart..."
-    checkAccount $SENDER "3" "9007199254710000"
-    checkAccount $RECV "0" "30992"
+    checkAccount $SENDER "9007199254710000"
+    checkAccount $RECV "30992"
 
     # make sure tx is indexed
     checkSendTx $HASH $TX_HEIGHT $SENDER "10000"


### PR DESCRIPTION
Remove the sequence number from coins (as Rigel is building a replacement), and finish implementing the fee module as a middleware that uses IPC (inter-plugin communication) to charge the fees as needed.

Add this meaning to the `--fee` flag in the cli and test

Note: every chain defines one currency in which to charge fees, and can optionally set a minimum value for it.