### PR TITLE
Add a flag to skip all query proofs

### DIFF
--- a/client/commands/init.go
+++ b/client/commands/init.go
@@ -29,9 +29,10 @@ var (
 
 //nolint
 const (
-	SeedFlag    = "seed"
-	HashFlag    = "valhash"
-	GenesisFlag = "genesis"
+	SeedFlag      = "seed"
+	HashFlag      = "valhash"
+	GenesisFlag   = "genesis"
+	FlagTrustNode = "trust-node"
 
 	ConfigFile = "config.toml"
 )
@@ -125,6 +126,11 @@ type Runable func(cmd *cobra.Command, args []string) error
 // and the root command sets up viper, which is needed to find the home dir.
 func RequireInit(run Runable) Runable {
 	return func(cmd *cobra.Command, args []string) error {
+		// otherwise, run the wrappped command
+		if viper.GetBool(FlagTrustNode) {
+			return run(cmd, args)
+		}
+
 		// first check if we were Init'ed and if not, return an error
 		root := viper.GetString(cli.HomeFlag)
 		init, err := WasInited(root)

--- a/client/commands/proofs/get.go
+++ b/client/commands/proofs/get.go
@@ -46,7 +46,7 @@ func GetProof(node client.Client, prover lc.Prover, key []byte, height int) (pro
 	}
 
 	// short-circuit with no proofs
-	if viper.GetBool(FlagTrustNode) {
+	if viper.GetBool(commands.FlagTrustNode) {
 		return proof, err
 	}
 

--- a/client/commands/proofs/root.go
+++ b/client/commands/proofs/root.go
@@ -26,4 +26,5 @@ func init() {
 	RootCmd.PersistentFlags().Int(FlagHeight, 0, "Height to query (skip to use latest block)")
 	RootCmd.PersistentFlags().Bool(commands.FlagTrustNode, false,
 		"DANGEROUS: blindly trust all results from the server")
+	RootCmd.PersistentFlags().MarkHidden(commands.FlagTrustNode)
 }

--- a/client/commands/proofs/root.go
+++ b/client/commands/proofs/root.go
@@ -1,6 +1,9 @@
 package proofs
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	"github.com/tendermint/basecoin/client/commands"
+)
 
 // nolint
 const (
@@ -22,5 +25,6 @@ data to other peers as needed.
 
 func init() {
 	RootCmd.Flags().Int(FlagHeight, 0, "Height to query (skip to use latest block)")
-	RootCmd.Flags().Bool(FlagTrustNode, false, "DANGEROUS: blindly trust all results from the server")
+	RootCmd.Flags().Bool(commands.FlagTrustNode, false,
+		"DANGEROUS: blindly trust all results from the server")
 }

--- a/client/commands/proofs/root.go
+++ b/client/commands/proofs/root.go
@@ -7,8 +7,7 @@ import (
 
 // nolint
 const (
-	FlagHeight    = "height"
-	FlagTrustNode = "trust-node"
+	FlagHeight = "height"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -24,7 +23,7 @@ data to other peers as needed.
 }
 
 func init() {
-	RootCmd.Flags().Int(FlagHeight, 0, "Height to query (skip to use latest block)")
-	RootCmd.Flags().Bool(commands.FlagTrustNode, false,
+	RootCmd.PersistentFlags().Int(FlagHeight, 0, "Height to query (skip to use latest block)")
+	RootCmd.PersistentFlags().Bool(commands.FlagTrustNode, false,
 		"DANGEROUS: blindly trust all results from the server")
 }

--- a/client/commands/proofs/root.go
+++ b/client/commands/proofs/root.go
@@ -2,8 +2,10 @@ package proofs
 
 import "github.com/spf13/cobra"
 
+// nolint
 const (
-	heightFlag = "height"
+	FlagHeight    = "height"
+	FlagTrustNode = "trust-node"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -19,5 +21,6 @@ data to other peers as needed.
 }
 
 func init() {
-	RootCmd.Flags().Int(heightFlag, 0, "Height to query (skip to use latest block)")
+	RootCmd.Flags().Int(FlagHeight, 0, "Height to query (skip to use latest block)")
+	RootCmd.Flags().Bool(FlagTrustNode, false, "DANGEROUS: blindly trust all results from the server")
 }

--- a/tests/cli/basictx.sh
+++ b/tests/cli/basictx.sh
@@ -86,13 +86,13 @@ test02SendTxWithFee() {
     # make sure this works without trust also
     OLD_BC_HOME=$BC_HOME
     export BC_HOME=/foo
-    export BCTRUST_NODE=1
-    export BCNODE=localhost:46657
+    export BC_TRUST_NODE=1
+    export BC_NODE=localhost:46657
     checkSendFeeTx $HASH $TX_HEIGHT $SENDER "90" "10"
     checkAccount $SENDER "9007199254739900"
     checkAccount $RECV "1082"
-    unset BCTRUST_NODE
-    unset BCNODE
+    unset BC_TRUST_NODE
+    unset BC_NODE
     export BC_HOME=$OLD_BC_HOME
 }
 

--- a/tests/cli/basictx.sh
+++ b/tests/cli/basictx.sh
@@ -66,20 +66,9 @@ test02SendTxWithFee() {
     # Make sure tx is indexed
     checkSendFeeTx $HASH $TX_HEIGHT $SENDER "90" "10"
 
-    # make sure this works without trust also
-    export BCTRUST_NODE=1
-    checkSendFeeTx $HASH $TX_HEIGHT $SENDER "90" "10"
-    unset BCTRUST_NODE
-
     # assert replay protection
     TX=$(echo qwertyuiop | ${CLIENT_EXE} tx send --amount=90mycoin --fee=10mycoin --sequence=2 --to=$RECV --name=$RICH 2>/dev/null)
     assertFalse "line=${LINENO}, replay: $TX" $?
-
-    # make sure this works without trust also
-    export BCTRUST_NODE=1
-    checkAccount $SENDER "9007199254739900"
-    checkAccount $RECV "1082"
-    unset BCTRUST_NODE
 
     # checking normally
     checkAccount $SENDER "9007199254739900"
@@ -93,6 +82,18 @@ test02SendTxWithFee() {
     if assertTrue "line=${LINENO}, no nonce query" $?; then
         assertEquals "line=${LINENO}, proper nonce" "2" $(echo $NONCE | jq .data)
     fi
+
+    # make sure this works without trust also
+    OLD_BC_HOME=$BC_HOME
+    export BC_HOME=/foo
+    export BCTRUST_NODE=1
+    export BCNODE=localhost:46657
+    checkSendFeeTx $HASH $TX_HEIGHT $SENDER "90" "10"
+    checkAccount $SENDER "9007199254739900"
+    checkAccount $RECV "1082"
+    unset BCTRUST_NODE
+    unset BCNODE
+    export BC_HOME=$OLD_BC_HOME
 }
 
 

--- a/tests/cli/basictx.sh
+++ b/tests/cli/basictx.sh
@@ -66,9 +66,22 @@ test02SendTxWithFee() {
     # Make sure tx is indexed
     checkSendFeeTx $HASH $TX_HEIGHT $SENDER "90" "10"
 
+    # make sure this works without trust also
+    export BCTRUST_NODE=1
+    checkSendFeeTx $HASH $TX_HEIGHT $SENDER "90" "10"
+    unset BCTRUST_NODE
+
     # assert replay protection
     TX=$(echo qwertyuiop | ${CLIENT_EXE} tx send --amount=90mycoin --fee=10mycoin --sequence=2 --to=$RECV --name=$RICH 2>/dev/null)
     assertFalse "line=${LINENO}, replay: $TX" $?
+
+    # make sure this works without trust also
+    export BCTRUST_NODE=1
+    checkAccount $SENDER "9007199254739900"
+    checkAccount $RECV "1082"
+    unset BCTRUST_NODE
+
+    # checking normally
     checkAccount $SENDER "9007199254739900"
     checkAccount $RECV "1082"
 


### PR DESCRIPTION
You can now add `--trust-node` or `export BC_TRUST_NODE=1` when running any `basecli query` subcommand and it doesn't do any proofs, and doesn't even require init.

Eg. on a running basecoin node, you can simply run:
`basecli query account 0EFF929AA4A6D561FC53C00A9F878B929CAF3040 --node=localhost:46657 --trust-node`
