### PR TITLE
cmd/baseserver: incorporate baseserver version + Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 shunit2
 docs/guide/*.sh
 keys/
+bin/

--- a/cmd/baseserver/Makefile
+++ b/cmd/baseserver/Makefile
@@ -1,0 +1,15 @@
+all: install linux darwin windows
+
+LINKER_FLAGS="-X main.CommitHash=`git rev-parse HEAD`"
+
+linux:
+	CGO_ENABLED=0 GOOS=linux go build -ldflags $(LINKER_FLAGS) -o ./bin/baseserver_linux
+
+windows:
+	CGO_ENABLED=0 GOOS=windows go build -ldflags $(LINKER_FLAGS) -o ./bin/baseserver_windows
+
+darwin:
+	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LINKER_FLAGS) -o ./bin/baseserver_darwin
+
+install:
+	go get -ldflags $(LINKER_FLAGS)

--- a/cmd/baseserver/README.md
+++ b/cmd/baseserver/README.md
@@ -2,13 +2,32 @@
 
 baseserver is the REST counterpart to basecli
 
-## Compiling and running it
+## Compiling
+
+### With Make
+```shell
+$ make install
+```
+
+### Cross compile binaries for linux, windows and darwin
+```shell
+$ make all
+```
+
+### Manually
 ```shell
 $ go get -u -v github.com/tendermint/basecoin/cmd/baseserver
+```
+
+Note: The recommended method of installing is `with make` rather
+than manually, since `with make` bakes into the respective binaries
+the version information, which helps in easy diagnosis.
+
+## Running it
+```shell
 $ baseserver init
 $ baseserver serve --port 8888
 ```
-
 to run the server at localhost:8888, otherwise if you don't specify --port,
 by default the server will be run on port 8998.
 

--- a/cmd/baseserver/main.go
+++ b/cmd/baseserver/main.go
@@ -29,6 +29,13 @@ var serveCmd = &cobra.Command{
 	RunE:  serve,
 }
 
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Version information about the light REST client for tendermint",
+	Long:  "Version information about the light REST client for tendermint",
+	RunE:  runVersion,
+}
+
 const (
 	envPortFlag = "port"
 	defaultAlgo = "ed25519"
@@ -69,12 +76,23 @@ func serve(cmd *cobra.Command, args []string) error {
 	return http.ListenAndServe(addr, router)
 }
 
+var (
+	version    = "0.0.1"
+	CommitHash = "<UNFILLED>"
+)
+
+func runVersion(cmd *cobra.Command, args []string) error {
+	fmt.Printf("%s:%s\n", version, CommitHash[:10])
+	return nil
+}
+
 func main() {
 	commands.AddBasicFlags(srvCli)
 
 	srvCli.AddCommand(
 		commands.InitCmd,
 		serveCmd,
+		versionCmd,
 	)
 
 	// TODO: Decide whether to use $HOME/.basecli for compatibility


### PR DESCRIPTION
From a discussion offline in which a teammate wasn't sure
if their PR was working, I suspect it was because perhaps
we were using a stale version of baseserver.
Now we can investigate what version their binary was built
against since we can bake that git commit hash in, and also
added a Makefile to install as well as cross compile binaries
for different architectures.

Note: The recommended way of building/installing baseserver
is `make install` or `make` as that will bake in all the version
information and help with future diagnosis.

* Exhibit
```shell
$ make install 1&>/dev/null 2&>/dev/null;baseserver version
0.0.1:a9df9aeef4
```